### PR TITLE
refactor: Optimize getAllTests query to apply LIMIT before joining at…

### DIFF
--- a/packages/reporter/src/__tests__/reporter.integration.test.ts
+++ b/packages/reporter/src/__tests__/reporter.integration.test.ts
@@ -609,18 +609,17 @@ describe('YShvydakReporter - Integration Tests', () => {
             reporter.onTestEnd(createMockTestCase('test', 'passed'), createMockTestResult('passed'))
 
             const result: FullResult = {status: 'passed'} as FullResult
-            const startTime = Date.now()
+            const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
             await reporter.onEnd(result)
-            const duration = Date.now() - startTime
 
-            // Should wait at least 1000ms
-            expect(duration).toBeGreaterThanOrEqual(1000)
+            expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000)
             expect(consoleLogSpy).toHaveBeenCalledWith(
                 expect.stringContaining('Waiting for all test results')
             )
             expect(consoleLogSpy).toHaveBeenCalledWith(
                 expect.stringContaining('All test results should be processed')
             )
+            setTimeoutSpy.mockRestore()
         })
 
         it('should handle API error when updating run', async () => {

--- a/packages/server/src/__tests__/integration/tests/createTestResult.integration.test.ts
+++ b/packages/server/src/__tests__/integration/tests/createTestResult.integration.test.ts
@@ -251,7 +251,7 @@ describe('POST /api/tests - Create Test Result (Integration)', () => {
 
             // Verify all 3 records exist in database
             const allResults = await server.testRepository.dbManager.queryAll(
-                'SELECT * FROM test_results WHERE test_id = ? ORDER BY created_at ASC',
+                'SELECT * FROM test_results WHERE test_id = ? ORDER BY created_at ASC, id ASC',
                 ['test-same-id']
             )
 

--- a/packages/server/src/repositories/__tests__/test.repository.test.ts
+++ b/packages/server/src/repositories/__tests__/test.repository.test.ts
@@ -775,6 +775,41 @@ describe('TestRepository - Core Functionality', () => {
             const expectedIds = executionIds.slice(-5).reverse() // Last 5, newest first
             expect(returnedIds).toEqual(expectedIds)
         })
+
+        it('should apply getAllTests LIMIT to tests before joining attachments', async () => {
+            const executionIds: string[] = []
+
+            for (let i = 0; i < 6; i++) {
+                const id = await repository.saveTestResult(
+                    createTestResult(`test-list-limit-${i}`, 'failed')
+                )
+                executionIds.push(id)
+
+                for (let j = 0; j < 3; j++) {
+                    await attachmentRepository.saveAttachment({
+                        id: `att-list-limit-${i}-${j}`,
+                        testResultId: id,
+                        type: j === 0 ? 'screenshot' : j === 1 ? 'video' : 'trace',
+                        fileName: `file-${i}-${j}.png`,
+                        filePath: `/path/to/file-${i}-${j}.png`,
+                        fileSize: 1024,
+                        url: `/attachments/file-${i}-${j}.png`,
+                    })
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            const limited = await repository.getAllTests({limit: 5})
+
+            expect(limited).toHaveLength(5)
+            limited.forEach((test) => {
+                expect(test.attachments).toHaveLength(3)
+            })
+
+            const returnedIds = limited.map((test) => test.id)
+            expect(returnedIds).toEqual(executionIds.slice(-5).reverse())
+        })
     })
 
     describe('clearAllTests()', () => {

--- a/packages/server/src/repositories/test.repository.ts
+++ b/packages/server/src/repositories/test.repository.ts
@@ -73,41 +73,43 @@ export class TestRepository extends BaseRepository implements ITestRepository {
     }
 
     async getAllTests(filters: TestFilters): Promise<TestResult[]> {
-        let sql = `
-            SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
-            FROM test_results tr
-            LEFT JOIN attachments a ON tr.id = a.test_result_id
-            LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
-        `
         const params: any[] = []
+        let innerSql: string
 
         if (filters.runId) {
-            sql += ` WHERE tr.run_id = ?`
+            innerSql = `SELECT * FROM test_results WHERE run_id = ?`
             params.push(filters.runId)
         } else {
             // Pick the latest execution per test_id with a window function (O(N log N))
             // instead of a correlated subquery (O(N^2)) — important once history grows.
-            sql = `
-                SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
+            innerSql = `
+                SELECT *
                 FROM (
                     SELECT *,
                            ROW_NUMBER() OVER (PARTITION BY test_id ORDER BY updated_at DESC) AS rn
                     FROM test_results
-                ) tr
-                LEFT JOIN attachments a ON tr.id = a.test_result_id
-                LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
-                WHERE tr.rn = 1
+                )
+                WHERE rn = 1
             `
         }
 
         if (filters.status) {
-            sql += filters.runId ? ` AND` : ` AND`
-            sql += ` tr.status = ?`
+            innerSql += ` AND status = ?`
             params.push(filters.status)
         }
 
-        sql += ` ORDER BY tr.updated_at DESC LIMIT ?`
+        // Apply LIMIT before joining attachments so attachment fan-out cannot
+        // shrink the number of test executions returned to the UI.
+        innerSql += ` ORDER BY updated_at DESC LIMIT ?`
         params.push(filters.limit || DEFAULT_LIMITS.TESTS_PER_PAGE)
+
+        const sql = `
+            SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
+            FROM (${innerSql}) tr
+            LEFT JOIN attachments a ON tr.id = a.test_result_id
+            LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
+            ORDER BY tr.updated_at DESC
+        `
 
         const rows = await this.queryAll<TestResultRow>(sql, params)
         return this.mapRowsToTestResults(rows)


### PR DESCRIPTION
…tachments

- Modified the getAllTests method to ensure that the LIMIT is applied to test results prior to joining with attachments, preventing excessive data retrieval.
- Updated SQL query structure for improved performance and clarity.
- Added a test case to verify that the LIMIT functionality works as intended, ensuring only the specified number of test results are returned while maintaining attachment integrity.