### PR TITLE
feat: Show dashboard storage footprint as stacked segment in disk bar

### DIFF
--- a/packages/web/src/features/dashboard/components/settings/SettingsStorageSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsStorageSection.tsx
@@ -52,6 +52,12 @@ export function SettingsStorageSection() {
     const disk = stats?.disk
     const freePercent = disk ? 100 - disk.usedPercent : null
 
+    const dashboardPercent =
+        stats?.total.size && disk
+            ? Math.min((stats.total.size / disk.total) * 100, disk.usedPercent)
+            : 0
+    const otherUsedPercent = disk ? Math.max(0, disk.usedPercent - dashboardPercent) : 0
+
     const diskStatus =
         !disk || !thresholds
             ? 'unknown'
@@ -131,16 +137,42 @@ export function SettingsStorageSection() {
                                     of {formatBytes(disk.total)}
                                 </span>
                             </div>
-                            <div className="w-full overflow-hidden rounded-full bg-gray-100 dark:bg-white/[0.08]">
-                                <div
-                                    className={`h-2 rounded-full transition-all duration-500 ${barColor}`}
-                                    style={{width: `${disk.usedPercent}%`}}
-                                />
+                            <div
+                                className="w-full overflow-hidden rounded-full bg-gray-100 dark:bg-white/[0.08]"
+                                style={{height: '8px'}}>
+                                <div className="flex h-full">
+                                    {dashboardPercent > 0 && (
+                                        <div
+                                            className="h-full bg-primary-500 transition-all duration-500"
+                                            style={{width: `${dashboardPercent}%`}}
+                                        />
+                                    )}
+                                    {otherUsedPercent > 0 && (
+                                        <div
+                                            className={`h-full transition-all duration-500 ${barColor}`}
+                                            style={{width: `${otherUsedPercent}%`}}
+                                        />
+                                    )}
+                                </div>
                             </div>
                             <div className="mt-1.5 flex justify-between text-xs text-gray-400 dark:text-gray-500">
                                 <span>{formatBytes(disk.used)} used</span>
                                 <span>{disk.usedPercent}%</span>
                             </div>
+                            {dashboardPercent > 0 && (
+                                <div className="mt-1.5 flex gap-3 text-xs text-gray-400 dark:text-gray-500">
+                                    <span className="flex items-center gap-1">
+                                        <span className="h-2 w-2 flex-shrink-0 rounded-full bg-primary-500" />
+                                        Dashboard {formatBytes(stats!.total.size)}
+                                    </span>
+                                    <span className="flex items-center gap-1">
+                                        <span
+                                            className={`h-2 w-2 flex-shrink-0 rounded-full ${barColor}`}
+                                        />
+                                        Other {formatBytes(disk.used - stats!.total.size)}
+                                    </span>
+                                </div>
+                            )}
                         </>
                     ) : (
                         <p className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary

- Splits the disk space progress bar in Storage settings into two visual segments: **primary blue** for dashboard data (DB + attachments) and the existing status color for other disk usage
- Adds a colour-coded legend below the bar showing exact byte counts for each segment (`● Dashboard X.XX GB  ● Other X.XX GB`)
- No new API calls — data was already available from the existing `useStorageStats` response (`stats.total.size` vs `disk.total`)

## Test plan

- [x] Open Settings → Storage and verify the progress bar shows two distinct segments when dashboard data exists
- [x] Verify the legend appears with correct byte values matching the Storage Details section
- [ ] Verify bar renders correctly at low usage (< 80%), warning (80–95%), and critical (> 95%) states
- [ ] Verify graceful fallback: if `stats.total.size` is 0 (no data), bar shows a single segment and legend is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)