### PR TITLE
feat: Set dark theme as default for new users

### DIFF
--- a/packages/web/src/features/authentication/components/LoginPage.tsx
+++ b/packages/web/src/features/authentication/components/LoginPage.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
 
     useEffect(() => {
         const savedTheme = localStorage.getItem('theme') as ThemeMode | null
-        const themeMode = savedTheme || 'auto'
+        const themeMode = savedTheme || 'dark'
 
         applyThemeMode(themeMode)
 

--- a/packages/web/src/hooks/__tests__/useTheme.test.ts
+++ b/packages/web/src/hooks/__tests__/useTheme.test.ts
@@ -265,6 +265,7 @@ describe('useTheme', () => {
         })
 
         it('should update listeners when theme mode changes', () => {
+            localStorage.setItem('theme', 'auto')
             const {result} = renderHook(() => useTheme())
 
             const initialAddCalls = mockMatchMedia.addEventListener.mock.calls.length
@@ -313,6 +314,7 @@ describe('useTheme', () => {
 
         it('should remove "dark" class when auto mode and system prefers light', () => {
             mockMatchMedia.matches = false
+            localStorage.setItem('theme', 'auto')
 
             renderHook(() => useTheme())
 

--- a/packages/web/src/hooks/__tests__/useTheme.test.ts
+++ b/packages/web/src/hooks/__tests__/useTheme.test.ts
@@ -50,10 +50,10 @@ describe('useTheme', () => {
     })
 
     describe('Initialization', () => {
-        it('should initialize with "auto" theme when no localStorage value', () => {
+        it('should initialize with "dark" theme when no localStorage value', () => {
             const {result} = renderHook(() => useTheme())
 
-            expect(result.current.themeMode).toBe('auto')
+            expect(result.current.themeMode).toBe('dark')
         })
 
         it('should initialize with saved theme from localStorage', () => {
@@ -157,6 +157,7 @@ describe('useTheme', () => {
 
         it('should set isDark based on system preference when theme is "auto"', () => {
             mockMatchMedia.matches = true
+            localStorage.setItem('theme', 'auto')
 
             const {result} = renderHook(() => useTheme())
 
@@ -166,6 +167,7 @@ describe('useTheme', () => {
 
         it('should set isDark to false when auto mode and system prefers light', () => {
             mockMatchMedia.matches = false
+            localStorage.setItem('theme', 'auto')
 
             const {result} = renderHook(() => useTheme())
 
@@ -198,6 +200,7 @@ describe('useTheme', () => {
 
         it('should update isDark when system preference changes in auto mode', () => {
             mockMatchMedia.matches = false
+            localStorage.setItem('theme', 'auto')
             const {result} = renderHook(() => useTheme())
 
             expect(result.current.isDark).toBe(false)
@@ -415,6 +418,7 @@ describe('useTheme', () => {
     describe('Integration Scenarios', () => {
         it('should handle complete theme cycle: auto -> dark -> light -> auto', () => {
             mockMatchMedia.matches = true
+            localStorage.setItem('theme', 'auto')
             const {result} = renderHook(() => useTheme())
 
             // Start with auto (system dark)
@@ -470,6 +474,7 @@ describe('useTheme', () => {
 
         it('should respond to system preference changes in real-time (auto mode)', () => {
             mockMatchMedia.matches = false
+            localStorage.setItem('theme', 'auto')
             const {result} = renderHook(() => useTheme())
 
             expect(result.current.isDark).toBe(false)
@@ -554,8 +559,8 @@ describe('useTheme', () => {
 
             const {result} = renderHook(() => useTheme())
 
-            // Should default to "auto" when empty
-            expect(result.current.themeMode).toBe('auto')
+            // Should default to "dark" when empty
+            expect(result.current.themeMode).toBe('dark')
         })
 
         it('should work when document element has other classes', () => {

--- a/packages/web/src/hooks/useTheme.ts
+++ b/packages/web/src/hooks/useTheme.ts
@@ -29,7 +29,7 @@ export function applyThemeMode(themeMode: ThemeMode): void {
 export function useTheme(): UseThemeReturn {
     const [themeMode, setThemeModeState] = useState<ThemeMode>(() => {
         const saved = localStorage.getItem('theme')
-        return (saved as ThemeMode) || 'auto'
+        return (saved as ThemeMode) || 'dark'
     })
 
     const [isDark, setIsDark] = useState(false)


### PR DESCRIPTION
## Summary

- Changed the default theme from `'auto'` (follows system preference) to `'dark'` for first-time users with no saved preference
- Updated `useTheme` tests to explicitly set `localStorage.theme = 'auto'` when testing auto-mode behavior, instead of relying on the fallback default

## Impact

- **New users** (no saved `localStorage.theme`): will see dark theme on first load
- **Existing users** with a saved theme preference: no change — their preference is preserved in `localStorage`

## Test plan

- [x] Open dashboard in a browser with cleared localStorage — dark theme should apply
- [x] Change theme to Light or Auto in Settings — should persist across reloads
- [x] All 2034 tests pass (70 test files, 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)