### PR TITLE
feat: Implement selective data cleanup for test results with attachme…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,9 @@ All agents are in `.claude/agents/` and use `disable-model-invocation: true` (ma
 - **Test configurations?** → `vitest.config.ts`, `packages/{package}/vitest.config.ts`
 - **Write tests?** → `packages/{package}/src/__tests__/`
 - Disk space thresholds? → `server/src/repositories/settings.repository.ts`
+- **Free space but keep history (strip attachments)?** → `server/src/services/test.service.ts` (`cleanupData` with `mode: 'strip' | 'full'`) + `server/src/repositories/attachmentCleanup.repository.ts` (`attachment_cleanups` table — INSERT-only marker, never UPDATE `test_results`)
+- Execution history pagination (keyset "load more" + honest total)? → `web/src/features/tests/hooks/useTestExecutionHistory.ts` + `getTestResultsByTestId(testId, limit, before)` / `getTestExecutionCount` in `test.repository.ts`
+- "Attachments removed to free space" UI? → `web/src/features/tests/components/testDetail/TestOverviewTab.tsx` + `history/ExecutionItem.tsx` (driven by `attachmentsClearedAt`)
 - Disk warning banner? → `web/src/features/dashboard/components/DiskSpaceWarningBanner.tsx`
 - Disk warning hook? → `web/src/features/dashboard/hooks/useDiskSpaceWarning.ts`
 - Search input (with ⌘K hint)? → `web/src/shared/components/molecules/SearchInput.tsx` (props: `showShortcutHint`, `onClear`, `resultCount`)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -314,25 +314,34 @@ Clear all test data from the database.
 
 **✨ New in v1.4.0** - Selective data cleanup to manage storage.
 
-**Description**: Clean up historical test data based on date or retention count per test. This action permanently deletes database records and their associated physical attachment files.
+**Description**: Free disk space from historical test data based on date or retention count per test.
+
+Two modes (`mode` parameter):
+
+- **`strip`** (default): deletes only the physical attachments (videos, traces, screenshots) and their `attachments` rows. The `test_results` rows are **kept**, so the Test Execution Timeline and per-test history are preserved. Stripped executions are recorded in `attachment_cleanups` so the UI can show "Attachments removed to free space". The most recent execution per test is never stripped.
+- **`full`**: permanently deletes the matching `test_results` rows _and_ their attachments (the original behaviour). This shrinks the timeline.
+
+**✨ Updated in v1.8.0** — added the `strip`/`full` mode. Prior versions always behaved like `full`.
 
 **Authentication**: Required (JWT token)
 
-**Request Body (Date-based):**
+**Request Body (Date-based, strip default):**
 
 ```json
 {
     "type": "date",
-    "value": "2023-01-01T00:00:00.000Z"
+    "value": "2023-01-01T00:00:00.000Z",
+    "mode": "strip"
 }
 ```
 
-**Request Body (Count-based):**
+**Request Body (Count-based, full delete):**
 
 ```json
 {
     "type": "count",
-    "value": 20
+    "value": 20,
+    "mode": "full"
 }
 ```
 
@@ -340,6 +349,7 @@ Clear all test data from the database.
 
 - `type` (required) - Cleanup strategy: `"date"` (older than date) or `"count"` (retain latest N per test)
 - `value` (required) - ISO date string for `"date"` type, or integer number for `"count"` type
+- `mode` (optional) - `"strip"` (default, keeps history) or `"full"` (deletes executions)
 
 **Response (200 - Success):**
 
@@ -349,10 +359,13 @@ Clear all test data from the database.
     "data": {
         "deletedExecutions": 45,
         "freedSpace": 52428800,
-        "message": "Successfully deleted 45 executions"
+        "message": "Freed space from 45 executions (history kept)",
+        "mode": "strip"
     }
 }
 ```
+
+`freedSpace` is computed from the `attachments.file_size` column (an indexed aggregate), and `deletedExecutions` counts the executions stripped (or deleted in `full` mode).
 
 **Response (400 - Bad Request):**
 
@@ -378,15 +391,15 @@ Clear all test data from the database.
 }
 ```
 
-**What Gets Deleted:**
+**What Gets Removed:**
 
-1. **Database Records**: Rows in `test_results` matching the criteria
-2. **Physical Files**: Attachments for the deleted executions are removed _before_ DB deletion
+- **`strip` mode**: physical attachment files + `attachments` rows only. `test_results` rows are kept and marked in `attachment_cleanups`.
+- **`full` mode**: physical attachment files _and_ the matching `test_results` rows.
 
 **Use Cases:**
 
-- "Delete data older than 30 days"
-- "Keep only the last 20 runs for each test" to cap database size
+- "Free space but keep the timeline" → `strip` (default): remove attachments older than 30 days, or keep attachments only for the latest 20 runs per test
+- "Permanently prune history" → `full`: delete executions older than 30 days, or keep only the last 20 runs per test
 
 ## Test Execution
 
@@ -1026,6 +1039,10 @@ Get complete execution history for a specific test.
 **Query Parameters:**
 
 - `limit` - Maximum number of historical executions to return (default: 50)
+- `byTestId` - Set `true`/`1`/`yes` when `id` is already the stable `testId` (skips an extra lookup)
+- `before` - ISO `createdAt` cursor for keyset pagination. Returns the next page of executions older than this timestamp. Pass the `createdAt` of the last item from the previous page to "load more".
+
+The response `count` field is the **total** execution count for the test (excludes pending/skipped placeholders), not the page length — use it to show "N of TOTAL" and to decide whether more pages remain. Each execution may include `attachmentsClearedAt` (ISO timestamp) when its attachments were stripped to free space via `strip` cleanup.
 
 **Response:**
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,6 +16,10 @@ export interface TestResult {
     steps?: TestStep[]
     attachments?: Attachment[]
     note?: TestNote
+    // ISO timestamp set when this execution's attachments were stripped to free
+    // disk space (the execution itself is kept for history/timeline). Undefined
+    // means attachments were never purged.
+    attachmentsClearedAt?: string
 }
 
 export type ConsoleEntryType = 'stdout' | 'stderr'

--- a/packages/server/src/controllers/__tests__/test.controller.test.ts
+++ b/packages/server/src/controllers/__tests__/test.controller.test.ts
@@ -86,6 +86,7 @@ describe('TestController', () => {
             getTestById: vi.fn(),
             rerunTest: vi.fn(),
             getTestHistory: vi.fn(),
+            getTestExecutionCount: vi.fn().mockResolvedValue(0),
             getDiagnostics: vi.fn(),
             getTraceFileById: vi.fn(),
         }
@@ -771,11 +772,13 @@ describe('TestController', () => {
             mockReq.params = {id: 'result-1'}
             mockTestService.getTestById.mockResolvedValue(test)
             mockTestService.getTestHistory.mockResolvedValue(history)
+            mockTestService.getTestExecutionCount.mockResolvedValue(2)
 
             await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
 
             expect(mockTestService.getTestById).toHaveBeenCalledWith('result-1')
-            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 50)
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 50, undefined)
+            // count meta is the TOTAL execution count, not the page length
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, history, undefined, 2)
         })
 
@@ -784,10 +787,11 @@ describe('TestController', () => {
             mockReq.params = {id: 'test-1'}
             mockTestService.getTestById.mockResolvedValue(null)
             mockTestService.getTestHistory.mockResolvedValue(history)
+            mockTestService.getTestExecutionCount.mockResolvedValue(2)
 
             await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
 
-            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 50)
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 50, undefined)
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, history, undefined, 2)
         })
 
@@ -800,7 +804,21 @@ describe('TestController', () => {
 
             await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
 
-            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 10)
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('test-1', 10, undefined)
+        })
+
+        it('should forward the keyset cursor when before is provided', async () => {
+            mockReq.params = {id: 'test-1'}
+            mockReq.query = {byTestId: 'true', before: '2026-05-01T00:00:00.000Z'}
+            mockTestService.getTestHistory.mockResolvedValue([])
+
+            await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
+
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith(
+                'test-1',
+                50,
+                '2026-05-01T00:00:00.000Z'
+            )
         })
 
         it('should skip getTestById lookup when byTestId=true', async () => {
@@ -808,11 +826,16 @@ describe('TestController', () => {
             mockReq.params = {id: 'stable-test-id'}
             mockReq.query = {byTestId: 'true'}
             mockTestService.getTestHistory.mockResolvedValue(history)
+            mockTestService.getTestExecutionCount.mockResolvedValue(2)
 
             await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
 
             expect(mockTestService.getTestById).not.toHaveBeenCalled()
-            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('stable-test-id', 50)
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith(
+                'stable-test-id',
+                50,
+                undefined
+            )
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, history, undefined, 2)
         })
 
@@ -824,7 +847,11 @@ describe('TestController', () => {
             await controller.getTestHistory(mockReq as ServiceRequest, mockRes as Response)
 
             expect(mockTestService.getTestById).not.toHaveBeenCalled()
-            expect(mockTestService.getTestHistory).toHaveBeenCalledWith('stable-test-id', 50)
+            expect(mockTestService.getTestHistory).toHaveBeenCalledWith(
+                'stable-test-id',
+                50,
+                undefined
+            )
         })
 
         it('should handle errors when fetching history', async () => {

--- a/packages/server/src/controllers/test.controller.ts
+++ b/packages/server/src/controllers/test.controller.ts
@@ -272,7 +272,7 @@ export class TestController {
     // POST /api/tests/cleanup - Selective data cleanup
     cleanupData = async (req: ServiceRequest, res: Response): Promise<Response> => {
         try {
-            const {type, value} = req.body
+            const {type, value, mode = 'strip'} = req.body
 
             if (!type || !value) {
                 return ResponseHelper.badRequest(res, 'Missing required fields: type, value')
@@ -282,7 +282,11 @@ export class TestController {
                 return ResponseHelper.badRequest(res, 'Invalid type. Must be "date" or "count"')
             }
 
-            const result = await this.testService.cleanupData({type, value})
+            if (mode !== 'strip' && mode !== 'full') {
+                return ResponseHelper.badRequest(res, 'Invalid mode. Must be "strip" or "full"')
+            }
+
+            const result = await this.testService.cleanupData({type, value, mode})
 
             return ResponseHelper.success(res, result)
         } catch (error) {
@@ -409,7 +413,7 @@ export class TestController {
     getTestHistory = async (req: ServiceRequest, res: Response): Promise<void> => {
         try {
             const {id} = req.params
-            const {limit = 50, byTestId} = req.query
+            const {limit = 50, byTestId, before} = req.query
 
             const isExplicitTestId = byTestId === 'true' || byTestId === '1' || byTestId === 'yes'
 
@@ -423,12 +427,19 @@ export class TestController {
                 testId = test ? test.testId : id
             }
 
-            const history = await this.testService.getTestHistory(
-                testId,
-                parseInt(limit as string) || 50
-            )
+            // `before` is an ISO created_at cursor for keyset pagination (load more).
+            // The meta `count` is the TOTAL execution count so the UI can show an
+            // honest "N of TOTAL" rather than the page size.
+            const [history, total] = await Promise.all([
+                this.testService.getTestHistory(
+                    testId,
+                    parseInt(limit as string) || 50,
+                    typeof before === 'string' ? before : undefined
+                ),
+                this.testService.getTestExecutionCount(testId),
+            ])
 
-            ResponseHelper.success(res, history, undefined, history.length)
+            ResponseHelper.success(res, history, undefined, total)
             return
         } catch (error) {
             Logger.error('Error fetching test history', error)

--- a/packages/server/src/database/__tests__/database.manager.test.ts
+++ b/packages/server/src/database/__tests__/database.manager.test.ts
@@ -938,8 +938,8 @@ describe('DatabaseManager', () => {
                 expect(totalSizeAfter).toBeLessThan(totalSizeBefore * 0.2)
 
                 // Database should be minimal size (just schema + indexes)
-                // Typical empty schema size is 32-150 KB depending on indexes
-                expect(totalSizeAfter).toBeLessThan(150 * 1024) // Less than 150 KB
+                // Typical empty schema size is 32-160 KB depending on indexes
+                expect(totalSizeAfter).toBeLessThan(160 * 1024) // Less than 160 KB
             } finally {
                 // Cleanup
                 fileDb.close()

--- a/packages/server/src/database/schema.sql
+++ b/packages/server/src/database/schema.sql
@@ -65,6 +65,17 @@ CREATE TABLE IF NOT EXISTS note_images (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Attachment cleanups (executions whose attachments were stripped to free disk space).
+-- The test_results row is intentionally KEPT so the timeline and execution history
+-- survive; this table only records that the artifacts (video/trace/screenshot/log)
+-- were purged and when. It lets the UI distinguish "removed to free space" from
+-- "this execution never had any attachments". INSERT-only — test_results is never mutated.
+CREATE TABLE IF NOT EXISTS attachment_cleanups (
+    test_result_id TEXT PRIMARY KEY REFERENCES test_results(id) ON DELETE CASCADE,
+    cleared_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    freed_bytes INTEGER DEFAULT 0
+);
+
 -- Application settings (global dashboard configuration)
 CREATE TABLE IF NOT EXISTS app_settings (
     key TEXT PRIMARY KEY,

--- a/packages/server/src/middleware/service-injection.middleware.ts
+++ b/packages/server/src/middleware/service-injection.middleware.ts
@@ -3,6 +3,7 @@ import {DatabaseManager} from '../database/database.manager'
 import {TestRepository} from '../repositories/test.repository'
 import {RunRepository} from '../repositories/run.repository'
 import {AttachmentRepository} from '../repositories/attachment.repository'
+import {AttachmentCleanupRepository} from '../repositories/attachmentCleanup.repository'
 import {StorageRepository} from '../repositories/storage.repository'
 import {NoteRepository} from '../repositories/note.repository'
 import {NoteImageRepository} from '../repositories/noteImage.repository'
@@ -25,6 +26,7 @@ export interface ServiceContainer {
     testRepository: TestRepository
     runRepository: RunRepository
     attachmentRepository: AttachmentRepository
+    attachmentCleanupRepository: AttachmentCleanupRepository
     storageRepository: StorageRepository
     noteRepository: NoteRepository
     noteImageRepository: NoteImageRepository
@@ -53,6 +55,7 @@ export async function createServiceContainer(): Promise<ServiceContainer> {
     const testRepository = new TestRepository(dbManager)
     const runRepository = new RunRepository(dbManager)
     const attachmentRepository = new AttachmentRepository(dbManager)
+    const attachmentCleanupRepository = new AttachmentCleanupRepository(dbManager)
     const storageRepository = new StorageRepository(dbManager, attachmentManager)
     const noteRepository = new NoteRepository(dbManager)
     const noteImageRepository = new NoteImageRepository(dbManager)
@@ -74,13 +77,15 @@ export async function createServiceContainer(): Promise<ServiceContainer> {
         websocketService,
         attachmentService,
         noteService,
-        settingsService
+        settingsService,
+        attachmentCleanupRepository
     )
 
     return {
         testRepository,
         runRepository,
         attachmentRepository,
+        attachmentCleanupRepository,
         storageRepository,
         noteRepository,
         noteImageRepository,

--- a/packages/server/src/repositories/__tests__/attachmentCleanup.repository.test.ts
+++ b/packages/server/src/repositories/__tests__/attachmentCleanup.repository.test.ts
@@ -1,0 +1,52 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest'
+import {AttachmentCleanupRepository} from '../attachmentCleanup.repository'
+
+const mockExecute = vi.fn()
+
+describe('AttachmentCleanupRepository', () => {
+    let repository: AttachmentCleanupRepository
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        repository = new AttachmentCleanupRepository({execute: mockExecute} as any)
+    })
+
+    describe('markCleared', () => {
+        it('should upsert all executions in a single batched multi-row statement', async () => {
+            await repository.markCleared([
+                {testResultId: 'a', freedBytes: 100},
+                {testResultId: 'b', freedBytes: 250},
+            ])
+
+            // Batched: one round-trip for both rows.
+            expect(mockExecute).toHaveBeenCalledTimes(1)
+            const [sql, params] = mockExecute.mock.calls[0]
+            expect(sql).toContain('INSERT INTO attachment_cleanups')
+            expect(sql).toContain('ON CONFLICT(test_result_id) DO UPDATE')
+            // Two value tuples, 3 bound params each (id, cleared_at, freed_bytes).
+            expect(sql).toContain('(?, ?, ?), (?, ?, ?)')
+            expect(params).toHaveLength(6)
+            expect(params[0]).toBe('a')
+            expect(params[2]).toBe(100)
+            expect(params[3]).toBe('b')
+            expect(params[5]).toBe(250)
+        })
+
+        it('should split into multiple statements beyond the batch size', async () => {
+            const entries = Array.from({length: 301}, (_, i) => ({
+                testResultId: `id-${i}`,
+                freedBytes: i,
+            }))
+
+            await repository.markCleared(entries)
+
+            // 301 rows → 300 + 1 across two batches.
+            expect(mockExecute).toHaveBeenCalledTimes(2)
+        })
+
+        it('should be a no-op for an empty list', async () => {
+            await repository.markCleared([])
+            expect(mockExecute).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/server/src/repositories/__tests__/test.repository.retention.test.ts
+++ b/packages/server/src/repositories/__tests__/test.repository.retention.test.ts
@@ -4,6 +4,7 @@ import {TestRepository} from '../test.repository'
 // Mock DatabaseManager
 const mockExecute = vi.fn()
 const mockQueryAll = vi.fn()
+const mockQueryOne = vi.fn()
 const mockCompact = vi.fn()
 
 vi.mock('../../database/database.manager', () => {
@@ -12,6 +13,7 @@ vi.mock('../../database/database.manager', () => {
             getInstance: () => ({
                 execute: mockExecute,
                 queryAll: mockQueryAll,
+                queryOne: mockQueryOne,
                 compactDatabase: mockCompact,
             }),
         },
@@ -27,6 +29,7 @@ describe('TestRepository Retention', () => {
         dbManager = {
             execute: mockExecute,
             queryAll: mockQueryAll,
+            queryOne: mockQueryOne,
             compactDatabase: mockCompact,
         }
 
@@ -58,6 +61,102 @@ describe('TestRepository Retention', () => {
                 expect.stringContaining('ROW_NUMBER() OVER'),
                 [5]
             )
+        })
+    })
+
+    describe('getStrippableIdsOlderThan', () => {
+        it('should select rows older than date, never the latest run (rn > 1), only with attachments', async () => {
+            const date = new Date('2026-01-01')
+            mockQueryAll.mockResolvedValueOnce([{id: 'old-2'}, {id: 'old-3'}])
+
+            const ids = await repository.getStrippableIdsOlderThan(date)
+
+            expect(ids).toEqual(['old-2', 'old-3'])
+            const [sql, params] = mockQueryAll.mock.calls[0]
+            // never strips the most recent execution per test
+            expect(sql).toContain('tr.rn > 1')
+            // only targets executions that still have attachments
+            expect(sql).toContain('EXISTS')
+            expect(sql).toContain('FROM attachments')
+            expect(params).toEqual([date.toISOString()])
+        })
+    })
+
+    describe('getStrippableIdsByCount', () => {
+        it('should select rows beyond the latest N per test that still have attachments', async () => {
+            mockQueryAll.mockResolvedValueOnce([{id: 'a'}])
+
+            const ids = await repository.getStrippableIdsByCount(20)
+
+            expect(ids).toEqual(['a'])
+            const [sql, params] = mockQueryAll.mock.calls[0]
+            expect(sql).toContain('ROW_NUMBER() OVER')
+            expect(sql).toContain('EXISTS')
+            expect(params).toEqual([20])
+        })
+    })
+
+    describe('getAttachmentsSizeForIds', () => {
+        it('should return total and per-id sizes from the DB', async () => {
+            mockQueryAll.mockResolvedValueOnce([
+                {id: 'a', size: 100},
+                {id: 'b', size: 250},
+            ])
+
+            const result = await repository.getAttachmentsSizeForIds(['a', 'b'])
+
+            expect(result.total).toBe(350)
+            expect(result.perId).toEqual({a: 100, b: 250})
+            const [sql] = mockQueryAll.mock.calls[0]
+            expect(sql).toContain('SUM(file_size)')
+            expect(sql).toContain('GROUP BY test_result_id')
+        })
+
+        it('should short-circuit on empty input without querying', async () => {
+            const result = await repository.getAttachmentsSizeForIds([])
+            expect(result).toEqual({total: 0, perId: {}})
+            expect(mockQueryAll).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('getTestExecutionCount', () => {
+        it('should return the count excluding pending/skipped placeholders', async () => {
+            mockQueryOne.mockResolvedValueOnce({count: 7})
+
+            const count = await repository.getTestExecutionCount('hash-1')
+
+            expect(count).toBe(7)
+            const [sql, params] = mockQueryOne.mock.calls[0]
+            expect(sql).toContain("status NOT IN ('pending', 'skipped')")
+            expect(params).toEqual(['hash-1'])
+        })
+
+        it('should return 0 when no row is returned', async () => {
+            mockQueryOne.mockResolvedValueOnce(null)
+            const count = await repository.getTestExecutionCount('hash-1')
+            expect(count).toBe(0)
+        })
+    })
+
+    describe('getTestResultsByTestId (keyset cursor)', () => {
+        it('should add a created_at cursor clause when `before` is provided', async () => {
+            mockQueryAll.mockResolvedValueOnce([])
+
+            await repository.getTestResultsByTestId('hash-1', 50, '2026-05-01T00:00:00.000Z')
+
+            const [sql, params] = mockQueryAll.mock.calls[0]
+            expect(sql).toContain('created_at < ?')
+            expect(params).toEqual(['hash-1', '2026-05-01T00:00:00.000Z', 50])
+        })
+
+        it('should omit the cursor clause when `before` is absent', async () => {
+            mockQueryAll.mockResolvedValueOnce([])
+
+            await repository.getTestResultsByTestId('hash-1', 50)
+
+            const [sql, params] = mockQueryAll.mock.calls[0]
+            expect(sql).not.toContain('created_at < ?')
+            expect(params).toEqual(['hash-1', 50])
         })
     })
 

--- a/packages/server/src/repositories/attachmentCleanup.repository.ts
+++ b/packages/server/src/repositories/attachmentCleanup.repository.ts
@@ -1,0 +1,44 @@
+import {BaseRepository} from './base.repository'
+
+export interface AttachmentCleanupEntry {
+    testResultId: string
+    freedBytes: number
+}
+
+/**
+ * Records executions whose attachments were stripped to free disk space.
+ *
+ * INSERT-only by design: the `test_results` row is never mutated. When a strip
+ * cleanup runs we add a marker here so the UI can show "Attachments removed to
+ * free space" instead of confusing the user with a bare "No attachments".
+ */
+export class AttachmentCleanupRepository extends BaseRepository {
+    /**
+     * Marks executions as having had their attachments stripped. Idempotent:
+     * re-marking an execution refreshes its timestamp and freed-bytes figure.
+     */
+    async markCleared(entries: AttachmentCleanupEntry[]): Promise<void> {
+        if (entries.length === 0) return
+
+        const clearedAt = new Date().toISOString()
+
+        // Batch into multi-row upserts (3 bound params per row, kept under SQLite's
+        // variable limit) instead of one round-trip per execution.
+        const ROWS_PER_BATCH = 300
+
+        for (let i = 0; i < entries.length; i += ROWS_PER_BATCH) {
+            const batch = entries.slice(i, i + ROWS_PER_BATCH)
+            const placeholders = batch.map(() => '(?, ?, ?)').join(', ')
+            const params = batch.flatMap((e) => [e.testResultId, clearedAt, e.freedBytes])
+
+            await this.execute(
+                `INSERT INTO attachment_cleanups (test_result_id, cleared_at, freed_bytes)
+                 VALUES ${placeholders}
+                 ON CONFLICT(test_result_id) DO UPDATE SET
+                     cleared_at = excluded.cleared_at,
+                     freed_bytes = excluded.freed_bytes`,
+                params
+            )
+        }
+    }
+}

--- a/packages/server/src/repositories/test.repository.ts
+++ b/packages/server/src/repositories/test.repository.ts
@@ -17,7 +17,16 @@ const TEST_RESULT_WITH_RELATIONS_COLUMNS = `
     a.mime_type   as attachment_mime_type,
     tn.content    as note_content,
     tn.created_at as note_created_at,
-    tn.updated_at as note_updated_at
+    tn.updated_at as note_updated_at,
+    ac.cleared_at as attachments_cleared_at
+`
+
+// Shared JOIN clause for the relations projection above. attachment_cleanups marks
+// executions whose attachments were stripped to free space (history kept).
+const TEST_RESULT_RELATIONS_JOINS = `
+    LEFT JOIN attachments a ON tr.id = a.test_result_id
+    LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
+    LEFT JOIN attachment_cleanups ac ON tr.id = ac.test_result_id
 `
 
 export class TestRepository extends BaseRepository implements ITestRepository {
@@ -26,21 +35,27 @@ export class TestRepository extends BaseRepository implements ITestRepository {
     }
 
     async getTestResult(id: string): Promise<TestResult | null> {
-        const row = await this.queryOne<TestResultRow>(`SELECT * FROM test_results WHERE id = ?`, [
-            id,
-        ])
+        // Use the same relations projection as the bulk reads so a single-execution
+        // lookup also carries attachments, note and attachmentsClearedAt — otherwise
+        // the "Attachments removed to free space" indicator breaks on this path.
+        const rows = await this.queryAll<TestResultRow>(
+            `SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
+             FROM test_results tr
+             ${TEST_RESULT_RELATIONS_JOINS}
+             WHERE tr.id = ?`,
+            [id]
+        )
 
-        if (!row) return null
+        if (rows.length === 0) return null
 
-        return this.mapRowToTestResult(row)
+        return this.mapRowsToTestResults(rows)[0]
     }
 
     async getTestResultsByRun(runId: string): Promise<TestResult[]> {
         const rows = await this.queryAll<TestResultRow>(
             `SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
              FROM test_results tr
-             LEFT JOIN attachments a ON tr.id = a.test_result_id
-             LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
+             ${TEST_RESULT_RELATIONS_JOINS}
              WHERE tr.run_id = ?
              ORDER BY tr.created_at DESC`,
             [runId]
@@ -51,25 +66,51 @@ export class TestRepository extends BaseRepository implements ITestRepository {
 
     async getTestResultsByTestId(
         testId: string,
-        limit = DEFAULT_LIMITS.TEST_HISTORY
+        limit = DEFAULT_LIMITS.TEST_HISTORY,
+        before?: string
     ): Promise<TestResult[]> {
+        // Keyset pagination: when `before` (an ISO created_at cursor) is supplied we
+        // fetch the next page of older executions. This stays O(limit) regardless of
+        // how deep the history is, leaning on idx_test_results_test_id_created_at.
+        //
         // Important: LIMIT is applied to the inner subquery so that history depth
         // is bounded by execution count, not by the row count after attachment JOIN.
+        const params: any[] = [testId]
+        let cursorClause = ''
+        if (before) {
+            cursorClause = ' AND created_at < ?'
+            params.push(before)
+        }
+        params.push(limit)
+
         const rows = await this.queryAll<TestResultRow>(
             `SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
              FROM (
                 SELECT * FROM test_results
-                WHERE test_id = ? AND status NOT IN ('pending', 'skipped')
+                WHERE test_id = ? AND status NOT IN ('pending', 'skipped')${cursorClause}
                 ORDER BY created_at DESC
                 LIMIT ?
              ) tr
-             LEFT JOIN attachments a ON tr.id = a.test_result_id
-             LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
+             ${TEST_RESULT_RELATIONS_JOINS}
              ORDER BY tr.created_at DESC`,
-            [testId, limit]
+            params
         )
 
         return this.mapRowsToTestResults(rows)
+    }
+
+    /**
+     * Total number of real executions (excludes discovered/skipped placeholders)
+     * for a test. Used so the history sidebar can show an honest "N of TOTAL"
+     * count instead of silently capping at the page size.
+     */
+    async getTestExecutionCount(testId: string): Promise<number> {
+        const row = await this.queryOne<{count: number}>(
+            `SELECT COUNT(*) as count FROM test_results
+             WHERE test_id = ? AND status NOT IN ('pending', 'skipped')`,
+            [testId]
+        )
+        return row?.count || 0
     }
 
     async getAllTests(filters: TestFilters): Promise<TestResult[]> {
@@ -106,8 +147,7 @@ export class TestRepository extends BaseRepository implements ITestRepository {
         const sql = `
             SELECT ${TEST_RESULT_WITH_RELATIONS_COLUMNS}
             FROM (${innerSql}) tr
-            LEFT JOIN attachments a ON tr.id = a.test_result_id
-            LEFT JOIN test_notes tn ON tr.test_id = tn.test_id
+            ${TEST_RESULT_RELATIONS_JOINS}
             ORDER BY tr.updated_at DESC
         `
 
@@ -242,6 +282,81 @@ export class TestRepository extends BaseRepository implements ITestRepository {
         return rows.map((row) => row.id)
     }
 
+    /**
+     * Executions older than `date` whose attachments can be stripped to free space.
+     * The most recent execution per test (rn = 1) is always preserved regardless of
+     * age — it's the one most likely to be opened for debugging. Already-stripped or
+     * never-had-attachments executions are skipped via the EXISTS check.
+     */
+    async getStrippableIdsOlderThan(date: Date): Promise<string[]> {
+        const sql = `
+            SELECT tr.id FROM (
+                SELECT id, created_at,
+                       ROW_NUMBER() OVER (PARTITION BY test_id ORDER BY created_at DESC) AS rn
+                FROM test_results
+            ) tr
+            WHERE tr.created_at < ?
+                AND tr.rn > 1
+                AND EXISTS (SELECT 1 FROM attachments a WHERE a.test_result_id = tr.id)
+        `
+        const rows = await this.queryAll<{id: string}>(sql, [date.toISOString()])
+        return rows.map((row) => row.id)
+    }
+
+    /**
+     * Executions beyond the latest `keepCount` per test whose attachments can be
+     * stripped. Mirrors getIdsPrunedByCount but only targets rows that still have
+     * attachments, so re-running the cleanup is a no-op once stripped.
+     */
+    async getStrippableIdsByCount(keepCount: number): Promise<string[]> {
+        const sql = `
+            SELECT tr.id FROM test_results tr
+            WHERE tr.id NOT IN (
+                SELECT id FROM (
+                    SELECT id, ROW_NUMBER() OVER (PARTITION BY test_id ORDER BY created_at DESC) as rn
+                    FROM test_results
+                ) t
+                WHERE t.rn <= ?
+            )
+            AND EXISTS (SELECT 1 FROM attachments a WHERE a.test_result_id = tr.id)
+        `
+        const rows = await this.queryAll<{id: string}>(sql, [keepCount])
+        return rows.map((row) => row.id)
+    }
+
+    /**
+     * Sums attachment file sizes for the given executions, both in total and broken
+     * down per execution. Replaces scanning the attachments directory twice — the
+     * sizes are already in the DB, so this is a single indexed aggregate.
+     */
+    async getAttachmentsSizeForIds(
+        ids: string[]
+    ): Promise<{total: number; perId: Record<string, number>}> {
+        if (ids.length === 0) return {total: 0, perId: {}}
+
+        const BATCH_SIZE = 900
+        const perId: Record<string, number> = {}
+        let total = 0
+
+        for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+            const batch = ids.slice(i, i + BATCH_SIZE)
+            const placeholders = batch.map(() => '?').join(',')
+            const rows = await this.queryAll<{id: string; size: number}>(
+                `SELECT test_result_id as id, COALESCE(SUM(file_size), 0) as size
+                 FROM attachments
+                 WHERE test_result_id IN (${placeholders})
+                 GROUP BY test_result_id`,
+                batch
+            )
+            rows.forEach((row) => {
+                perId[row.id] = row.size
+                total += row.size
+            })
+        }
+
+        return {total, perId}
+    }
+
     async deleteByIds(ids: string[]): Promise<number> {
         if (ids.length === 0) return 0
 
@@ -281,6 +396,7 @@ export class TestRepository extends BaseRepository implements ITestRepository {
             timestamp: row.created_at,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
+            attachmentsClearedAt: row.attachments_cleared_at || undefined,
             attachments: [],
         }
     }

--- a/packages/server/src/services/__tests__/test.service.test.ts
+++ b/packages/server/src/services/__tests__/test.service.test.ts
@@ -28,6 +28,7 @@ vi.mock('../activeProcesses.service', () => ({
         addProcess: vi.fn(),
         removeProcess: vi.fn(),
         isProcessRunning: vi.fn(() => true),
+        isAnyProcessRunning: vi.fn(() => false),
         isRunAllActive: vi.fn(() => false),
         getActiveProcesses: vi.fn(() => []),
     },
@@ -42,6 +43,7 @@ describe('TestService', () => {
     let mockAttachmentService: any
     let mockNoteService: any
     let mockSettingsService: any
+    let mockAttachmentCleanupRepository: any
 
     // Helper to create mock child process
     const createMockProcess = (): ChildProcess => {
@@ -73,6 +75,13 @@ describe('TestService', () => {
             getTestStats: vi.fn(),
             getFlakyTests: vi.fn(),
             getTestTimeline: vi.fn(),
+            getTestExecutionCount: vi.fn(),
+            getIdsOlderThan: vi.fn(),
+            getIdsPrunedByCount: vi.fn(),
+            getStrippableIdsOlderThan: vi.fn(),
+            getStrippableIdsByCount: vi.fn(),
+            getAttachmentsSizeForIds: vi.fn().mockResolvedValue({total: 0, perId: {}}),
+            deleteByIds: vi.fn().mockResolvedValue(0),
         }
 
         mockRunRepository = {
@@ -119,6 +128,10 @@ describe('TestService', () => {
             setGlobalPlaywrightProject: vi.fn(),
         }
 
+        mockAttachmentCleanupRepository = {
+            markCleared: vi.fn().mockResolvedValue(undefined),
+        }
+
         // Create service instance
         testService = new TestService(
             mockTestRepository,
@@ -127,7 +140,8 @@ describe('TestService', () => {
             mockWebSocketService,
             mockAttachmentService,
             mockNoteService,
-            mockSettingsService
+            mockSettingsService,
+            mockAttachmentCleanupRepository
         )
     })
 
@@ -398,7 +412,11 @@ describe('TestService', () => {
             const history = await testService.getTestHistory('hash-1', 50)
 
             expect(history).toEqual(mockHistory)
-            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith('hash-1', 50)
+            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith(
+                'hash-1',
+                50,
+                undefined
+            )
             // Critical: history must NOT issue per-execution attachment queries
             expect(mockAttachmentService.getAttachmentsByTestResult).not.toHaveBeenCalled()
         })
@@ -408,7 +426,11 @@ describe('TestService', () => {
 
             await testService.getTestHistory('hash-1')
 
-            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith('hash-1', 50)
+            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith(
+                'hash-1',
+                50,
+                undefined
+            )
         })
 
         it('should handle custom limit', async () => {
@@ -416,7 +438,23 @@ describe('TestService', () => {
 
             await testService.getTestHistory('hash-1', 10)
 
-            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith('hash-1', 10)
+            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith(
+                'hash-1',
+                10,
+                undefined
+            )
+        })
+
+        it('should forward the keyset cursor for load-more', async () => {
+            mockTestRepository.getTestResultsByTestId.mockResolvedValue([])
+
+            await testService.getTestHistory('hash-1', 50, '2026-05-01T00:00:00.000Z')
+
+            expect(mockTestRepository.getTestResultsByTestId).toHaveBeenCalledWith(
+                'hash-1',
+                50,
+                '2026-05-01T00:00:00.000Z'
+            )
         })
 
         it('should handle empty history', async () => {
@@ -1698,6 +1736,104 @@ describe('TestService', () => {
             expect(mockAttachmentService.deleteAttachmentsForTestResult).toHaveBeenCalledWith(
                 executionId
             )
+        })
+    })
+
+    describe('getTestExecutionCount', () => {
+        it('should delegate to the repository', async () => {
+            mockTestRepository.getTestExecutionCount.mockResolvedValue(42)
+
+            const count = await testService.getTestExecutionCount('test-1')
+
+            expect(count).toBe(42)
+            expect(mockTestRepository.getTestExecutionCount).toHaveBeenCalledWith('test-1')
+        })
+    })
+
+    describe('cleanupData', () => {
+        it('should default to strip mode: delete attachments, keep rows, mark cleared', async () => {
+            mockTestRepository.getStrippableIdsByCount.mockResolvedValue(['a', 'b'])
+            mockTestRepository.getAttachmentsSizeForIds.mockResolvedValue({
+                total: 300,
+                perId: {a: 100, b: 200},
+            })
+            mockAttachmentService.deleteAttachmentsForTestResult.mockResolvedValue(1)
+
+            const result = await testService.cleanupData({type: 'count', value: 20})
+
+            expect(result.mode).toBe('strip')
+            expect(result.deletedExecutions).toBe(2)
+            expect(result.freedSpace).toBe(300)
+            // rows are NOT deleted in strip mode
+            expect(mockTestRepository.deleteByIds).not.toHaveBeenCalled()
+            // cleared markers recorded with per-execution freed bytes
+            expect(mockAttachmentCleanupRepository.markCleared).toHaveBeenCalledWith([
+                {testResultId: 'a', freedBytes: 100},
+                {testResultId: 'b', freedBytes: 200},
+            ])
+            expect(mockTestRepository.getStrippableIdsByCount).toHaveBeenCalledWith(20)
+        })
+
+        it('should use strip date selection that preserves the latest run', async () => {
+            mockTestRepository.getStrippableIdsOlderThan.mockResolvedValue(['old-1'])
+            mockTestRepository.getAttachmentsSizeForIds.mockResolvedValue({
+                total: 50,
+                perId: {'old-1': 50},
+            })
+
+            const result = await testService.cleanupData({
+                type: 'date',
+                value: '2026-01-01T00:00:00.000Z',
+                mode: 'strip',
+            })
+
+            expect(mockTestRepository.getStrippableIdsOlderThan).toHaveBeenCalledTimes(1)
+            expect(result.freedSpace).toBe(50)
+            expect(mockTestRepository.deleteByIds).not.toHaveBeenCalled()
+        })
+
+        it('should delete rows in full mode and not record cleanups', async () => {
+            mockTestRepository.getIdsPrunedByCount.mockResolvedValue(['a', 'b', 'c'])
+            mockTestRepository.getAttachmentsSizeForIds.mockResolvedValue({
+                total: 900,
+                perId: {a: 300, b: 300, c: 300},
+            })
+            mockTestRepository.deleteByIds.mockResolvedValue(3)
+
+            const result = await testService.cleanupData({
+                type: 'count',
+                value: 5,
+                mode: 'full',
+            })
+
+            expect(result.mode).toBe('full')
+            expect(result.deletedExecutions).toBe(3)
+            expect(result.freedSpace).toBe(900)
+            expect(mockTestRepository.deleteByIds).toHaveBeenCalledWith(['a', 'b', 'c'])
+            expect(mockAttachmentCleanupRepository.markCleared).not.toHaveBeenCalled()
+        })
+
+        it('should no-op when nothing matches', async () => {
+            mockTestRepository.getStrippableIdsByCount.mockResolvedValue([])
+
+            const result = await testService.cleanupData({type: 'count', value: 20})
+
+            expect(result.deletedExecutions).toBe(0)
+            expect(result.freedSpace).toBe(0)
+            expect(mockAttachmentService.deleteAttachmentsForTestResult).not.toHaveBeenCalled()
+            expect(mockAttachmentCleanupRepository.markCleared).not.toHaveBeenCalled()
+        })
+
+        it('should reject invalid count', async () => {
+            await expect(testService.cleanupData({type: 'count', value: 0})).rejects.toThrow(
+                'Invalid count provided'
+            )
+        })
+
+        it('should reject invalid date', async () => {
+            await expect(
+                testService.cleanupData({type: 'date', value: 'not-a-date'})
+            ).rejects.toThrow('Invalid date provided')
         })
     })
 })

--- a/packages/server/src/services/test.service.ts
+++ b/packages/server/src/services/test.service.ts
@@ -8,6 +8,7 @@ import {
 import {TestResultData} from '../types/database.types'
 import {TestRepository} from '../repositories/test.repository'
 import {RunRepository} from '../repositories/run.repository'
+import {AttachmentCleanupRepository} from '../repositories/attachmentCleanup.repository'
 import {PlaywrightService} from './playwright.service'
 import {WebSocketService} from './websocket.service'
 import {AttachmentService} from './attachment.service'
@@ -25,7 +26,8 @@ export class TestService implements ITestService {
         private websocketService: WebSocketService,
         private attachmentService: AttachmentService,
         private noteService: NoteService,
-        private settingsService: SettingsService
+        private settingsService: SettingsService,
+        private attachmentCleanupRepository: AttachmentCleanupRepository
     ) {}
 
     private async getExecutionProject(): Promise<string | undefined> {
@@ -85,10 +87,19 @@ export class TestService implements ITestService {
         return test
     }
 
-    async getTestHistory(testId: string, limit: number = 50): Promise<TestResult[]> {
+    async getTestHistory(
+        testId: string,
+        limit: number = 50,
+        before?: string
+    ): Promise<TestResult[]> {
         // Attachments and notes are loaded via JOIN inside the repository, so a
         // single SQL roundtrip is sufficient — no per-execution N+1 fan-out here.
-        return this.testRepository.getTestResultsByTestId(testId, limit)
+        // `before` enables keyset pagination for long histories.
+        return this.testRepository.getTestResultsByTestId(testId, limit, before)
+    }
+
+    async getTestExecutionCount(testId: string): Promise<number> {
+        return this.testRepository.getTestExecutionCount(testId)
     }
 
     async deleteTest(testId: string): Promise<{deletedExecutions: number}> {
@@ -148,50 +159,72 @@ export class TestService implements ITestService {
         await this.attachmentService.clearAllAttachments()
     }
 
-    async cleanupData(options: {type: 'date' | 'count'; value: string | number}): Promise<{
+    async cleanupData(options: {
+        type: 'date' | 'count'
+        value: string | number
+        mode?: 'strip' | 'full'
+    }): Promise<{
         deletedExecutions: number
         freedSpace: number
         message: string
+        mode: 'strip' | 'full'
     }> {
         // Prevent cleanup if tests are running
         if (activeProcessesTracker.isAnyProcessRunning()) {
             throw new Error('Cannot clean up data while tests are running')
         }
 
-        let idsToDelete: string[] = []
+        // 'strip' (default) frees disk space but keeps test_results rows, so the
+        // timeline and history survive. 'full' removes the executions entirely.
+        const mode: 'strip' | 'full' = options.mode ?? 'strip'
 
+        // Resolve & validate the selection criterion once.
+        let date: Date | null = null
+        let count = 0
         if (options.type === 'date') {
-            const date = new Date(options.value as string)
+            date = new Date(options.value as string)
             if (isNaN(date.getTime())) {
                 throw new Error('Invalid date provided')
             }
-            idsToDelete = await this.testRepository.getIdsOlderThan(date)
         } else if (options.type === 'count') {
-            const count = parseInt(options.value as string)
+            count = parseInt(options.value as string)
             if (isNaN(count) || count < 1) {
                 throw new Error('Invalid count provided')
             }
-            idsToDelete = await this.testRepository.getIdsPrunedByCount(count)
         }
 
-        if (idsToDelete.length === 0) {
+        // Select the affected executions. In strip mode we only target rows that
+        // still have attachments (and never the latest run per test).
+        let ids: string[] = []
+        if (mode === 'strip') {
+            ids =
+                options.type === 'date'
+                    ? await this.testRepository.getStrippableIdsOlderThan(date!)
+                    : await this.testRepository.getStrippableIdsByCount(count)
+        } else {
+            ids =
+                options.type === 'date'
+                    ? await this.testRepository.getIdsOlderThan(date!)
+                    : await this.testRepository.getIdsPrunedByCount(count)
+        }
+
+        if (ids.length === 0) {
             return {
                 deletedExecutions: 0,
                 freedSpace: 0,
                 message: 'No data matched the cleanup criteria',
+                mode,
             }
         }
 
-        Logger.info(`Cleanup: found ${idsToDelete.length} executions to delete`)
+        Logger.info(`Cleanup (${mode}): found ${ids.length} executions to process`)
 
-        // 1. Delete attachments (physical files)
-        let totalFreedSpace = 0
-        const statsBefore = await this.attachmentService.getStorageStats()
+        // Measure freed space from the DB (file_size column) before deleting files —
+        // a single indexed aggregate, no double directory scan.
+        const {total: freedSpace, perId} = await this.testRepository.getAttachmentsSizeForIds(ids)
 
-        // We can't easily track per-file size deleted here without extra queries,
-        // so we'll just check stats before/after or rely on attachment service logs.
-        // For now, let's just delete.
-        for (const id of idsToDelete) {
+        // Delete physical attachment files + their DB rows for every affected execution.
+        for (const id of ids) {
             try {
                 await this.attachmentService.deleteAttachmentsForTestResult(id)
             } catch (error) {
@@ -199,20 +232,36 @@ export class TestService implements ITestService {
             }
         }
 
-        const statsAfter = await this.attachmentService.getStorageStats()
-        totalFreedSpace = statsBefore.totalSize - statsAfter.totalSize
+        if (mode === 'strip') {
+            // Keep the test_results rows; record that artifacts were purged so the UI
+            // can show "Attachments removed to free space" instead of "No attachments".
+            await this.attachmentCleanupRepository.markCleared(
+                ids.map((id) => ({testResultId: id, freedBytes: perId[id] || 0}))
+            )
 
-        // 2. Delete DB records
-        const deletedCount = await this.testRepository.deleteByIds(idsToDelete)
+            Logger.info(
+                `Cleanup complete (strip): freed ${freedSpace} bytes from ${ids.length} executions, history kept`
+            )
+
+            return {
+                deletedExecutions: ids.length,
+                freedSpace,
+                message: `Freed space from ${ids.length} executions (history kept)`,
+                mode,
+            }
+        }
+
+        const deletedCount = await this.testRepository.deleteByIds(ids)
 
         Logger.info(
-            `Cleanup complete: deleted ${deletedCount} records, freed ${totalFreedSpace} bytes`
+            `Cleanup complete (full): deleted ${deletedCount} records, freed ${freedSpace} bytes`
         )
 
         return {
             deletedExecutions: deletedCount,
-            freedSpace: totalFreedSpace,
+            freedSpace,
             message: `Successfully deleted ${deletedCount} executions`,
+            mode,
         }
     }
 

--- a/packages/server/src/types/database.types.ts
+++ b/packages/server/src/types/database.types.ts
@@ -25,6 +25,9 @@ export interface TestResultData {
     timestamp: string
     createdAt?: string
     updatedAt?: string
+    // ISO timestamp when this execution's attachments were stripped to free disk
+    // space (history kept). Undefined means attachments were never purged.
+    attachmentsClearedAt?: string
 }
 
 export interface AttachmentData {
@@ -65,6 +68,8 @@ export interface TestResultRow {
     note_content?: string
     note_created_at?: string
     note_updated_at?: string
+    // Joined attachment_cleanups field
+    attachments_cleared_at?: string
 }
 
 // Discovered test from Playwright

--- a/packages/server/src/types/service.types.ts
+++ b/packages/server/src/types/service.types.ts
@@ -6,7 +6,8 @@ export interface ITestService {
     discoverTests(): Promise<TestDiscoveryResult>
     getAllTests(filters: TestFilters): Promise<TestResult[]>
     getTestById(id: string): Promise<TestResult | null>
-    getTestHistory(testId: string, limit?: number): Promise<TestResult[]>
+    getTestHistory(testId: string, limit?: number, before?: string): Promise<TestResult[]>
+    getTestExecutionCount(testId: string): Promise<number>
     deleteTest(testId: string): Promise<{deletedExecutions: number}>
     deleteExecution(executionId: string): Promise<{success: boolean}>
     clearAllTests(): Promise<void>
@@ -19,12 +20,17 @@ export interface ITestService {
 export interface CleanupOptions {
     type: 'date' | 'count'
     value: string | number
+    // 'strip' (default): delete attachments only, keep test_results rows so the
+    // timeline and history survive. 'full': delete the executions entirely.
+    mode?: 'strip' | 'full'
 }
 
 export interface CleanupResult {
+    // Number of executions affected (stripped in 'strip' mode, deleted in 'full').
     deletedExecutions: number
     freedSpace: number
     message: string
+    mode: 'strip' | 'full'
 }
 
 export interface IPlaywrightService {
@@ -124,12 +130,20 @@ export interface ITestRepository {
     saveTestResult(testData: TestResultData): Promise<string>
     getTestResult(id: string): Promise<TestResult | null>
     getTestResultsByRun(runId: string): Promise<TestResult[]>
-    getTestResultsByTestId(testId: string, limit?: number): Promise<TestResult[]>
+    getTestResultsByTestId(testId: string, limit?: number, before?: string): Promise<TestResult[]>
+    getTestExecutionCount(testId: string): Promise<number>
     getAllTests(filters: TestFilters): Promise<TestResult[]>
     deleteByTestId(testId: string): Promise<number>
     deleteByExecutionId(executionId: string): Promise<number>
     clearAllTests(): Promise<void>
     getTestStats(): Promise<DatabaseStats>
+    // Retention / cleanup selection
+    getIdsOlderThan(date: Date): Promise<string[]>
+    getIdsPrunedByCount(keepCount: number): Promise<string[]>
+    getStrippableIdsOlderThan(date: Date): Promise<string[]>
+    getStrippableIdsByCount(keepCount: number): Promise<string[]>
+    getAttachmentsSizeForIds(ids: string[]): Promise<{total: number; perId: Record<string, number>}>
+    deleteByIds(ids: string[]): Promise<number>
 }
 
 export interface IRunRepository {

--- a/packages/web/src/features/dashboard/components/settings/SettingsStorageSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsStorageSection.tsx
@@ -1,6 +1,14 @@
-import {useState} from 'react'
-import {ChevronDown, ChevronRight, Database, HardDrive, Paperclip, RefreshCw} from 'lucide-react'
-import {Button} from '@shared/components'
+import {useEffect, useState} from 'react'
+import {
+    AlertTriangle,
+    ChevronDown,
+    ChevronRight,
+    Database,
+    HardDrive,
+    Paperclip,
+    RefreshCw,
+} from 'lucide-react'
+import {Button, ConfirmationDialog} from '@shared/components'
 import {SettingsSection} from './SettingsSection'
 import {useStorageStats, useDiskThresholds} from '../../hooks'
 import {useDashboardActions} from '../../hooks'
@@ -23,6 +31,18 @@ export function SettingsStorageSection() {
     const [thresholdsSynced, setThresholdsSynced] = useState(false)
     const [daysToKeep, setDaysToKeep] = useState('30')
     const [runsToKeep, setRunsToKeep] = useState('20')
+    // 'strip' frees space but keeps history; 'full' permanently deletes executions.
+    const [cleanupMode, setCleanupMode] = useState<'strip' | 'full'>('strip')
+    // Pending full-delete action awaiting confirmation (null = dialog closed).
+    const [confirmFull, setConfirmFull] = useState<null | {type: 'date' | 'count'}>(null)
+    // Which criterion is currently running, so only its button shows the spinner
+    // (cleaningData is shared across both rows).
+    const [pendingAction, setPendingAction] = useState<'date' | 'count' | null>(null)
+
+    // Clear the in-flight marker once the shared cleanup flag settles.
+    useEffect(() => {
+        if (!cleaningData) setPendingAction(null)
+    }, [cleaningData])
 
     if (thresholds && !thresholdsSynced) {
         setWarningInput(String(thresholds.warningPercent))
@@ -37,16 +57,44 @@ export function SettingsStorageSection() {
         saveThresholds({warningPercent: warning, criticalPercent: critical})
     }
 
-    const handleDeleteOld = () => {
-        if (!daysToKeep || isNaN(parseInt(daysToKeep))) return
+    const daysValid = !!daysToKeep && parseInt(daysToKeep) >= 1
+    const runsValid = !!runsToKeep && parseInt(runsToKeep) >= 1
+
+    // Convert "older than N days" into a cutoff at the START of the day N days ago,
+    // so the whole Nth day is kept (avoids the time-of-day off-by-one where a run
+    // made earlier on day N would otherwise count as older than the criterion).
+    const dateCutoff = () => {
         const date = new Date()
         date.setDate(date.getDate() - parseInt(daysToKeep))
-        cleanupData('date', date.toISOString())
+        date.setHours(0, 0, 0, 0)
+        return date.toISOString()
     }
 
-    const handlePruneCount = () => {
-        if (!runsToKeep || isNaN(parseInt(runsToKeep))) return
-        cleanupData('count', parseInt(runsToKeep))
+    // Single entry point for both criteria. In 'full' mode we route through the
+    // confirmation dialog; in 'strip' mode we run immediately.
+    const runAction = (type: 'date' | 'count') => {
+        if (type === 'date' ? !daysValid : !runsValid) return
+        if (cleanupMode === 'full') {
+            setConfirmFull({type})
+            return
+        }
+        setPendingAction(type)
+        if (type === 'date') {
+            cleanupData('date', dateCutoff(), 'strip')
+        } else {
+            cleanupData('count', parseInt(runsToKeep), 'strip')
+        }
+    }
+
+    const handleConfirmFull = () => {
+        if (!confirmFull) return
+        setPendingAction(confirmFull.type)
+        if (confirmFull.type === 'date') {
+            if (daysValid) cleanupData('date', dateCutoff(), 'full')
+        } else {
+            if (runsValid) cleanupData('count', parseInt(runsToKeep), 'full')
+        }
+        setConfirmFull(null)
     }
 
     const disk = stats?.disk
@@ -387,13 +435,52 @@ export function SettingsStorageSection() {
 
                 {/* ── CLEAN UP ──────────────────────────────── */}
                 <div className="border-t border-gray-200/70 pt-4 dark:border-white/[0.06]">
-                    <p className="mb-3.5 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                    <p className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
                         Clean Up
+                    </p>
+                    {/* Mode toggle: 'strip' keeps history, 'full' deletes executions */}
+                    <div className="mb-3 inline-flex rounded-lg bg-gray-100 p-0.5 dark:bg-white/[0.05]">
+                        <button
+                            onClick={() => setCleanupMode('strip')}
+                            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                                cleanupMode === 'strip'
+                                    ? 'bg-white text-gray-900 shadow-sm dark:bg-white/[0.12] dark:text-white'
+                                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                            }`}>
+                            Free space
+                        </button>
+                        <button
+                            onClick={() => setCleanupMode('full')}
+                            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                                cleanupMode === 'full'
+                                    ? 'bg-danger-500 text-white shadow-sm'
+                                    : 'text-gray-500 hover:text-danger-600 dark:text-gray-400 dark:hover:text-danger-400'
+                            }`}>
+                            Delete permanently
+                        </button>
+                    </div>
+
+                    <p
+                        className={`mb-3.5 flex items-start gap-1.5 text-xs ${
+                            cleanupMode === 'full'
+                                ? 'font-medium text-danger-600 dark:text-danger-400'
+                                : 'text-gray-500 dark:text-gray-400'
+                        }`}>
+                        {cleanupMode === 'full' && (
+                            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                        )}
+                        <span>
+                            {cleanupMode === 'strip'
+                                ? 'Frees disk space by deleting attachments (videos, traces, screenshots). Test history and the timeline are kept.'
+                                : 'Permanently deletes the matching executions, including their history. This shrinks the timeline and cannot be undone.'}
+                        </span>
                     </p>
 
                     <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-2 gap-y-3">
                         <span className="text-sm text-gray-700 dark:text-gray-300">
-                            Delete runs older than
+                            {cleanupMode === 'strip'
+                                ? 'Remove attachments older than'
+                                : 'Delete runs older than'}
                         </span>
                         <input
                             type="number"
@@ -407,16 +494,18 @@ export function SettingsStorageSection() {
                             days
                         </span>
                         <Button
-                            variant="secondary"
+                            variant={cleanupMode === 'strip' ? 'secondary' : 'danger'}
                             size="sm"
-                            loading={cleaningData}
-                            disabled={isAnyTestRunning || cleaningData}
-                            onClick={handleDeleteOld}>
-                            Delete
+                            loading={cleaningData && pendingAction === 'date'}
+                            disabled={isAnyTestRunning || cleaningData || !daysValid}
+                            onClick={() => runAction('date')}>
+                            {cleanupMode === 'strip' ? 'Free space' : 'Delete'}
                         </Button>
 
                         <span className="text-sm text-gray-700 dark:text-gray-300">
-                            Keep only latest
+                            {cleanupMode === 'strip'
+                                ? 'Keep attachments for latest'
+                                : 'Keep only latest'}
                         </span>
                         <input
                             type="number"
@@ -430,16 +519,32 @@ export function SettingsStorageSection() {
                             runs/test
                         </span>
                         <Button
-                            variant="secondary"
+                            variant={cleanupMode === 'strip' ? 'secondary' : 'danger'}
                             size="sm"
-                            loading={cleaningData}
-                            disabled={isAnyTestRunning || cleaningData}
-                            onClick={handlePruneCount}>
-                            Prune
+                            loading={cleaningData && pendingAction === 'count'}
+                            disabled={isAnyTestRunning || cleaningData || !runsValid}
+                            onClick={() => runAction('count')}>
+                            {cleanupMode === 'strip' ? 'Free space' : 'Prune'}
                         </Button>
                     </div>
                 </div>
             </div>
+
+            <ConfirmationDialog
+                isOpen={confirmFull !== null}
+                title="Delete permanently?"
+                description={
+                    confirmFull?.type === 'date'
+                        ? `This permanently deletes all executions older than ${daysToKeep} days, including their history. The timeline will shrink for that period. This cannot be undone.`
+                        : `This permanently deletes all but the latest ${runsToKeep} runs per test, including their history. The timeline will shrink. This cannot be undone.`
+                }
+                confirmText="Delete permanently"
+                cancelText="Cancel"
+                variant="danger"
+                isLoading={cleaningData}
+                onConfirm={handleConfirmFull}
+                onCancel={() => setConfirmFull(null)}
+            />
         </SettingsSection>
     )
 }

--- a/packages/web/src/features/dashboard/hooks/__tests__/useDashboardActions.test.tsx
+++ b/packages/web/src/features/dashboard/hooks/__tests__/useDashboardActions.test.tsx
@@ -266,4 +266,69 @@ describe('useDashboardActions', () => {
             })
         })
     })
+
+    describe('cleanupData', () => {
+        const cleanupResponse = (mode: 'strip' | 'full') => ({
+            ok: true,
+            json: async () => ({
+                data: {deletedExecutions: 4, freedSpace: 2 * 1024 * 1024, mode},
+            }),
+        })
+
+        it('should default to strip mode and send mode in the request body', async () => {
+            vi.mocked(authFetch.authFetch).mockResolvedValue(cleanupResponse('strip') as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.cleanupData('count', 20)
+
+            const [, options] = vi.mocked(authFetch.authFetch).mock.calls[0]
+            expect(JSON.parse((options as any).body)).toEqual({
+                type: 'count',
+                value: 20,
+                mode: 'strip',
+            })
+        })
+
+        it('should show a history-preserving message in strip mode', async () => {
+            vi.mocked(authFetch.authFetch).mockResolvedValue(cleanupResponse('strip') as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.cleanupData('count', 20, 'strip')
+
+            await waitFor(() => {
+                expect(alertSpy).toHaveBeenCalledWith(
+                    '✅ Freed 2.00 MB from 4 executions. Test history kept.'
+                )
+            })
+        })
+
+        it('should send full mode and show a deletion message', async () => {
+            vi.mocked(authFetch.authFetch).mockResolvedValue(cleanupResponse('full') as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.cleanupData('date', '2026-01-01T00:00:00.000Z', 'full')
+
+            const [, options] = vi.mocked(authFetch.authFetch).mock.calls[0]
+            expect(JSON.parse((options as any).body).mode).toBe('full')
+
+            await waitFor(() => {
+                expect(alertSpy).toHaveBeenCalledWith(
+                    '✅ Cleanup complete! Deleted 4 executions and freed 2.00 MB.'
+                )
+            })
+        })
+
+        it('should invalidate storage-stats after a successful cleanup', async () => {
+            vi.mocked(authFetch.authFetch).mockResolvedValue(cleanupResponse('strip') as any)
+            const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.cleanupData('count', 20)
+
+            await waitFor(() => {
+                expect(invalidateQueriesSpy).toHaveBeenCalledWith({queryKey: ['storage-stats']})
+                expect(mockFetchTests).toHaveBeenCalled()
+            })
+        })
+    })
 })

--- a/packages/web/src/features/dashboard/hooks/useDashboardActions.ts
+++ b/packages/web/src/features/dashboard/hooks/useDashboardActions.ts
@@ -8,7 +8,11 @@ export interface UseDashboardActionsReturn {
     clearingData: boolean
     cleaningData: boolean
     clearAllData: () => Promise<void>
-    cleanupData: (type: 'date' | 'count', value: string | number) => Promise<void>
+    cleanupData: (
+        type: 'date' | 'count',
+        value: string | number,
+        mode?: 'strip' | 'full'
+    ) => Promise<void>
 }
 
 export function useDashboardActions(): UseDashboardActionsReturn {
@@ -60,7 +64,11 @@ export function useDashboardActions(): UseDashboardActionsReturn {
         }
     }
 
-    const cleanupData = async (type: 'date' | 'count', value: string | number) => {
+    const cleanupData = async (
+        type: 'date' | 'count',
+        value: string | number,
+        mode: 'strip' | 'full' = 'strip'
+    ) => {
         setCleaningData(true)
         try {
             const response = await authFetch(`${config.api.baseUrl}/tests/cleanup`, {
@@ -68,7 +76,7 @@ export function useDashboardActions(): UseDashboardActionsReturn {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({type, value}),
+                body: JSON.stringify({type, value, mode}),
             })
 
             if (!response.ok) {
@@ -76,11 +84,13 @@ export function useDashboardActions(): UseDashboardActionsReturn {
             }
 
             const result = await response.json()
-            const {deletedExecutions, freedSpace} = result.data
+            const {deletedExecutions, freedSpace, mode: resultMode} = result.data
 
             const freedMb = (freedSpace / (1024 * 1024)).toFixed(2)
             alert(
-                `✅ Cleanup complete! Deleted ${deletedExecutions} executions and freed ${freedMb} MB.`
+                resultMode === 'strip'
+                    ? `✅ Freed ${freedMb} MB from ${deletedExecutions} executions. Test history kept.`
+                    : `✅ Cleanup complete! Deleted ${deletedExecutions} executions and freed ${freedMb} MB.`
             )
 
             fetchTests()

--- a/packages/web/src/features/tests/components/history/ExecutionItem.tsx
+++ b/packages/web/src/features/tests/components/history/ExecutionItem.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {Check, Timer, Paperclip} from 'lucide-react'
+import {Check, Timer, Paperclip, Archive} from 'lucide-react'
 import {TestResult} from '@yshvydak/core'
 import {StatusBadge} from '@shared/components'
 import {formatLastRun, formatDuration} from '../../utils/formatters'
@@ -21,6 +21,8 @@ export function ExecutionItem({
 }: ExecutionItemProps) {
     const [showRemoveButton, setShowRemoveButton] = useState(false)
     const attachmentCount = execution.attachments?.length || 0
+    // Attachments were purged to free disk space; the execution itself is kept.
+    const isStripped = !!execution.attachmentsClearedAt && attachmentCount === 0
 
     const handleDeleteClick = (e: React.MouseEvent) => {
         e.stopPropagation()
@@ -33,12 +35,25 @@ export function ExecutionItem({
         onSelect(execution.id)
     }
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        // Mirror native button activation: Enter and Space select the execution.
+        if (isCurrent) return
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onSelect(execution.id)
+        }
+    }
+
     return (
-        <button
+        <div
+            role="button"
+            tabIndex={isCurrent ? -1 : 0}
+            aria-disabled={isCurrent || undefined}
             onClick={handleClick}
+            onKeyDown={handleKeyDown}
             onMouseEnter={() => setShowRemoveButton(true)}
             onMouseLeave={() => setShowRemoveButton(false)}
-            className={`group w-full text-left rounded-xl p-3 transition-all duration-200 ${
+            className={`group w-full text-left rounded-xl p-3 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
                 isCurrent
                     ? 'bg-primary-50 ring-1 ring-inset ring-primary-600/20 shadow-soft cursor-default dark:bg-primary-500/15 dark:ring-primary-400/25'
                     : 'bg-white border border-gray-200/80 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-card-hover cursor-pointer dark:bg-gray-800/70 dark:border-white/[0.07] dark:hover:border-white/[0.12]'
@@ -68,6 +83,16 @@ export function ExecutionItem({
                         <span>•</span>
                         <span className="flex items-center gap-1">
                             <Paperclip className="h-3 w-3" /> {attachmentCount}
+                        </span>
+                    </>
+                )}
+                {isStripped && (
+                    <>
+                        <span>•</span>
+                        <span
+                            className="flex items-center gap-1 text-gray-400 dark:text-gray-500"
+                            title="Attachments removed to free disk space">
+                            <Archive className="h-3 w-3" /> archived
                         </span>
                     </>
                 )}
@@ -101,6 +126,6 @@ export function ExecutionItem({
                     </button>
                 )}
             </div>
-        </button>
+        </div>
     )
 }

--- a/packages/web/src/features/tests/components/history/ExecutionSidebar.tsx
+++ b/packages/web/src/features/tests/components/history/ExecutionSidebar.tsx
@@ -13,6 +13,10 @@ export interface ExecutionSidebarProps {
     onRerun: (testId: string) => void
     loading?: boolean
     error?: string
+    total?: number
+    hasMore?: boolean
+    onLoadMore?: () => void
+    loadingMore?: boolean
 }
 
 export function ExecutionSidebar({
@@ -24,6 +28,10 @@ export function ExecutionSidebar({
     onRerun,
     loading,
     error,
+    total,
+    hasMore,
+    onLoadMore,
+    loadingMore,
 }: ExecutionSidebarProps) {
     const {runningTests, getIsAnyTestRunning, activeProgress} = useTestsStore()
     const isAnyTestRunning = getIsAnyTestRunning()
@@ -48,8 +56,11 @@ export function ExecutionSidebar({
                             Execution History
                         </h3>
                         <p className="mt-1.5 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium tabular-nums text-gray-500 ring-1 ring-inset ring-gray-500/10 dark:bg-white/[0.06] dark:text-gray-400 dark:ring-white/10">
-                            {executions.length}{' '}
-                            {executions.length === 1 ? 'execution' : 'executions'}
+                            {typeof total === 'number' && total > executions.length
+                                ? `${executions.length} of ${total}`
+                                : `${executions.length} ${
+                                      executions.length === 1 ? 'execution' : 'executions'
+                                  }`}
                         </p>
                     </div>
                     <ActionButton
@@ -106,6 +117,15 @@ export function ExecutionSidebar({
                                 onDelete={onDeleteExecution}
                             />
                         ))}
+
+                        {hasMore && onLoadMore && (
+                            <button
+                                onClick={onLoadMore}
+                                disabled={loadingMore}
+                                className="w-full rounded-xl border border-dashed border-gray-300 px-3 py-2.5 text-xs font-medium text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-700 disabled:opacity-50 dark:border-white/10 dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-gray-200">
+                                {loadingMore ? 'Loading…' : 'Load more'}
+                            </button>
+                        )}
                     </div>
                 )}
             </div>

--- a/packages/web/src/features/tests/components/testDetail/TestDetailModal.tsx
+++ b/packages/web/src/features/tests/components/testDetail/TestDetailModal.tsx
@@ -110,6 +110,10 @@ export function TestDetailModal({test, isOpen, onClose}: TestDetailModalProps) {
 
     const {
         executions,
+        total: historyTotal,
+        hasMore: historyHasMore,
+        loadMore: loadMoreHistory,
+        loadingMore: historyLoadingMore,
         loading: historyLoading,
         error: historyError,
         refetch: refetchHistory,
@@ -338,6 +342,10 @@ export function TestDetailModal({test, isOpen, onClose}: TestDetailModalProps) {
                         <div className="hidden md:block h-full min-h-0">
                             <ExecutionSidebar
                                 executions={executions}
+                                total={historyTotal}
+                                hasMore={historyHasMore}
+                                onLoadMore={loadMoreHistory}
+                                loadingMore={historyLoadingMore}
                                 currentExecutionId={currentExecution?.id || test.id}
                                 onSelectExecution={handleSelectExecution}
                                 onDeleteExecution={handleDeleteExecutionClick}

--- a/packages/web/src/features/tests/components/testDetail/TestOverviewTab.tsx
+++ b/packages/web/src/features/tests/components/testDetail/TestOverviewTab.tsx
@@ -1,4 +1,4 @@
-import {Paperclip, Copy} from 'lucide-react'
+import {Paperclip, Copy, Archive} from 'lucide-react'
 import {TestResult} from '@yshvydak/core'
 import {LoadingSpinner} from '@shared/components'
 import {AttachmentWithBlobURL} from '../../types/attachment.types'
@@ -27,6 +27,11 @@ export function TestOverviewTab({
     onDeleteNote,
 }: TestOverviewTabProps) {
     const hasConsoleOutput = (test.metadata?.console?.entries?.length ?? 0) > 0
+    // Attachments were purged to free disk space (the execution itself is kept).
+    const isStripped = !!test.attachmentsClearedAt
+    const strippedDate = test.attachmentsClearedAt
+        ? new Date(test.attachmentsClearedAt).toLocaleDateString()
+        : ''
 
     return (
         <div className="space-y-6 animate-fade-in">
@@ -72,13 +77,21 @@ export function TestOverviewTab({
                 {!attachmentsLoading && !attachmentsError && attachments.length === 0 && (
                     <div className="flex flex-col items-center justify-center text-center py-12 bg-gray-50 dark:bg-white/[0.03] rounded-2xl border border-gray-200/70 dark:border-white/[0.06]">
                         <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gray-100 text-xl dark:bg-white/[0.04]">
-                            <Paperclip className="h-3.5 w-3.5" />
+                            {isStripped ? (
+                                <Archive className="h-3.5 w-3.5" />
+                            ) : (
+                                <Paperclip className="h-3.5 w-3.5" />
+                            )}
                         </div>
                         <p className="mt-3 text-sm font-medium text-gray-600 dark:text-gray-300">
-                            No attachments
+                            {isStripped ? 'Attachments removed to free space' : 'No attachments'}
                         </p>
                         <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-                            No attachments found for this test
+                            {isStripped
+                                ? `Videos, traces and screenshots were cleaned up${
+                                      strippedDate ? ` on ${strippedDate}` : ''
+                                  }. The execution is kept for history.`
+                                : 'No attachments found for this test'}
                         </p>
                     </div>
                 )}

--- a/packages/web/src/features/tests/hooks/useTestExecutionHistory.ts
+++ b/packages/web/src/features/tests/hooks/useTestExecutionHistory.ts
@@ -3,16 +3,26 @@ import {TestResult} from '@yshvydak/core'
 import {authGet} from '@features/authentication/utils/authFetch'
 import {config} from '@config/environment.config'
 
+// Page size for the execution-history sidebar. Loading a small first page keeps
+// the modal snappy; older pages are fetched on demand via keyset pagination.
+const PAGE_SIZE = 50
+
 export interface UseTestExecutionHistoryReturn {
     executions: TestResult[]
+    total: number
+    hasMore: boolean
     loading: boolean
+    loadingMore: boolean
     error: string | null
+    loadMore: () => void
     refetch: () => void
 }
 
 export function useTestExecutionHistory(testId: string): UseTestExecutionHistoryReturn {
     const [executions, setExecutions] = useState<TestResult[]>([])
+    const [total, setTotal] = useState(0)
     const [loading, setLoading] = useState(false)
+    const [loadingMore, setLoadingMore] = useState(false)
     const [error, setError] = useState<string | null>(null)
     const [refreshTrigger, setRefreshTrigger] = useState(0)
 
@@ -20,9 +30,11 @@ export function useTestExecutionHistory(testId: string): UseTestExecutionHistory
         setRefreshTrigger((prev) => prev + 1)
     }, [])
 
+    // First page (or reload). Replaces the list and resets the total.
     useEffect(() => {
         if (!testId) {
             setExecutions([])
+            setTotal(0)
             return
         }
 
@@ -34,12 +46,14 @@ export function useTestExecutionHistory(testId: string): UseTestExecutionHistory
                 // (not an execution id), so it can skip an extra SELECT + attachment
                 // lookup that exists for backwards-compatible execution-id callers.
                 const response = await authGet(
-                    `${config.api.serverUrl}/api/tests/${testId}/history?limit=200&byTestId=true`
+                    `${config.api.serverUrl}/api/tests/${testId}/history?limit=${PAGE_SIZE}&byTestId=true`
                 )
 
                 if (response.ok) {
                     const data = await response.json()
                     setExecutions(data.data || [])
+                    // `count` is the TOTAL execution count, not the page length.
+                    setTotal(typeof data.count === 'number' ? data.count : (data.data || []).length)
                 } else {
                     setError('Failed to load execution history')
                 }
@@ -53,5 +67,53 @@ export function useTestExecutionHistory(testId: string): UseTestExecutionHistory
         fetchHistory()
     }, [testId, refreshTrigger])
 
-    return {executions, loading, error, refetch}
+    // Fetch the next page of older executions using a keyset cursor (created_at of
+    // the last loaded row), which stays O(PAGE_SIZE) regardless of history depth.
+    const loadMore = useCallback(() => {
+        if (!testId || loadingMore || loading) return
+        if (executions.length >= total) return
+
+        const last = executions[executions.length - 1]
+        const cursor = last?.createdAt || last?.timestamp
+        if (!cursor) return
+
+        const fetchMore = async () => {
+            setLoadingMore(true)
+            try {
+                const response = await authGet(
+                    `${config.api.serverUrl}/api/tests/${testId}/history?limit=${PAGE_SIZE}&byTestId=true&before=${encodeURIComponent(cursor)}`
+                )
+
+                if (response.ok) {
+                    const data = await response.json()
+                    const next: TestResult[] = data.data || []
+                    // Guard against duplicate ids if executions arrive concurrently.
+                    setExecutions((prev) => {
+                        const seen = new Set(prev.map((e) => e.id))
+                        return [...prev, ...next.filter((e) => !seen.has(e.id))]
+                    })
+                    if (typeof data.count === 'number') setTotal(data.count)
+                } else {
+                    setError('Failed to load more history')
+                }
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Unknown error')
+            } finally {
+                setLoadingMore(false)
+            }
+        }
+
+        fetchMore()
+    }, [testId, executions, total, loadingMore, loading])
+
+    return {
+        executions,
+        total,
+        hasMore: executions.length < total,
+        loading,
+        loadingMore,
+        error,
+        loadMore,
+        refetch,
+    }
 }


### PR DESCRIPTION
…nt management

- Introduced a new cleanup feature allowing users to free disk space by selectively deleting historical test data while preserving execution history.
- Added two modes for cleanup: `strip` (default) which removes only attachments and keeps test results, and `full` which deletes both attachments and test results.
- Updated API documentation to reflect the new cleanup options and their effects on data retention.
- Enhanced the TestService and TestRepository to support the new cleanup logic, including methods for identifying strippable test results based on age and count.
- Implemented a new AttachmentCleanupRepository to track executions whose attachments were stripped, allowing the UI to indicate when attachments have been removed to free space.
- Added tests to ensure the new functionality works as intended and integrates seamlessly with existing features.