### PR TITLE
refactor: Remove text truncation in TestRow component

### DIFF
--- a/packages/web/src/features/tests/components/TestRow.tsx
+++ b/packages/web/src/features/tests/components/TestRow.tsx
@@ -5,7 +5,6 @@ import {StatusBadge, ActionButton, LoadingSpinner, Badge} from '@shared/componen
 import {formatDuration, formatLastRun} from '../utils'
 import {useTestsStore} from '../store/testsStore'
 import {LinkifiedText} from '@/components/atoms/LinkifiedText'
-import {truncateText} from '@/utils/linkify.util'
 import {useNoteImages} from '../hooks/useNoteImages'
 import {parseNoteContent} from '@/utils/noteContent.util'
 import {createProtectedFileURL} from '@features/authentication/utils/authFetch'
@@ -91,7 +90,7 @@ export function TestRow({test, selected, onSelect, onRerun}: TestRowProps) {
                                 return (
                                     <LinkifiedText
                                         key={`text-${index}`}
-                                        text={truncateText(part.content, 50)}
+                                        text={part.content}
                                         className="truncate"
                                     />
                                 )


### PR DESCRIPTION
- Eliminated the `truncateText` utility from the TestRow component, allowing full content display for test notes.
- Updated the rendering logic to directly use `part.content` instead of the truncated version, enhancing visibility of test details.