### PR TITLE
feat: Add project tab configurations and CI auto-run pause functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,18 @@
 Shared config stored in SQLite (survives restarts, visible to all users):
 
 - Pattern: `SettingsRepository` + UPSERT `ON CONFLICT(key) DO UPDATE`
-- Existing keys: `global_playwright_project`, `disk_warning_threshold_percent`, `disk_critical_threshold_percent`
+- Existing keys: `global_playwright_project`, `disk_warning_threshold_percent`, `disk_critical_threshold_percent`, `project_tab_configs`, `ci_autorun_paused`, `ci_autorun_resume_at`
 - Default values: handled in repository getter when row absent (e.g. 20%/5% for disk thresholds)
 - 📂 `packages/server/src/repositories/settings.repository.ts`
+
+### 8️⃣ CI Auto-run Pause — Temporarily Block CI-Triggered Runs
+
+- Toggle in Settings → CI Trigger Script → "Pause CI auto-run"
+- Stored in `app_settings`: keys `ci_autorun_paused`, `ci_autorun_resume_at`
+- Blocks only `source: 'script'` calls (from `trigger-test-run.js`) — UI-triggered runs still work
+- HTTP 423 `CI_AUTORUN_PAUSED` → script exits with code 2
+- Header banner: `CIAutoRunPauseBanner.tsx` + hook `useCIAutoRun.ts`
+- Two `useCIAutoRun()` instances don't share state — App.tsx calls `reload()` on Settings close
 
 ### 6️⃣ Context7-MCP Integration - MANDATORY for Dependencies
 
@@ -118,6 +127,9 @@ All agents are in `.claude/agents/` and use `disable-model-invocation: true` (ma
 - Disk warning hook? → `web/src/features/dashboard/hooks/useDiskSpaceWarning.ts`
 - Search input (with ⌘K hint)? → `web/src/shared/components/molecules/SearchInput.tsx` (props: `showShortcutHint`, `onClear`, `resultCount`)
 - Search URL persistence? → `TestsList.tsx` — `?q=` param, same pattern as `?filter=`
+- Project tabs (nav config)? → `web/src/hooks/useProjectTabs.ts` + `server/src/repositories/settings.repository.ts` (`project_tab_configs` key)
+- Project tab settings UI? → `web/src/features/dashboard/components/settings/SettingsProjectTabsSection.tsx`
+- Active project filter? → `web/src/features/tests/hooks/useTestFilters.ts` (`projectFilter` — strict match, `project === projectFilter`)
 
 **Full structure:** See [docs/ai/FILE_LOCATIONS.md](docs/ai/FILE_LOCATIONS.md)
 
@@ -210,6 +222,23 @@ Before committing any change to a value, constant, default, or behavior:
 3. **Search for parallel implementations** — if a hook/utility has a standalone fallback, pages that don't use that hook (e.g. pre-auth pages) likely have their own copy
 
 Rule: if you change X, ask "where else is X assumed to be true?" before pushing.
+
+### ❌ Assuming `playwright test --list --reporter=json` groups by project
+
+Top-level suites are per-FILE, not per-project. Project name is at `spec.tests[0].projectName`.
+The text output (`[All_Tests] › file`) looks project-grouped — the JSON output is NOT.
+
+### ❌ Editing reporter source without npm link
+
+`packages/reporter/src/index.ts` changes have NO effect on test projects (`probuild-qa` etc.)
+that install the reporter from npm. Changes only apply via `npm link` or publishing a new version.
+Prefer server-side fallbacks (e.g. `test_runs.metadata.project`) over reporter changes when possible.
+
+### ❌ Trusting tsx watch without a restart
+
+`tsx watch` may not pick up server file changes if the process has been running for a long time.
+After significant changes to `packages/server/src/` — restart the server manually (`Ctrl+C` → `npm run dev`).
+Symptom: authenticated requests to new routes return 404 while unauthenticated return 401 (old auth middleware fires, new handler never registered).
 
 **More examples:** [docs/ai/ANTI_PATTERNS.md](docs/ai/ANTI_PATTERNS.md)
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -20,6 +20,8 @@ export interface TestResult {
     // disk space (the execution itself is kept for history/timeline). Undefined
     // means attachments were never purged.
     attachmentsClearedAt?: string
+    // Playwright project this test was run under. Empty string = discovered/unrun.
+    project?: string
 }
 
 export type ConsoleEntryType = 'stdout' | 'stderr'

--- a/packages/server/src/controllers/__tests__/test.controller.test.ts
+++ b/packages/server/src/controllers/__tests__/test.controller.test.ts
@@ -211,7 +211,12 @@ describe('TestController', () => {
 
             await controller.runAllTests(mockReq as ServiceRequest, mockRes as Response)
 
-            expect(mockTestService.runAllTests).toHaveBeenCalledWith(4, undefined, undefined)
+            expect(mockTestService.runAllTests).toHaveBeenCalledWith(
+                4,
+                undefined,
+                undefined,
+                undefined
+            )
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, runResult)
         })
 
@@ -222,6 +227,7 @@ describe('TestController', () => {
             await controller.runAllTests(mockReq as ServiceRequest, mockRes as Response)
 
             expect(mockTestService.runAllTests).toHaveBeenCalledWith(
+                undefined,
                 undefined,
                 undefined,
                 undefined
@@ -238,7 +244,12 @@ describe('TestController', () => {
             await controller.runAllTests(mockReq as ServiceRequest, mockRes as Response)
 
             // Assert
-            expect(mockTestService.runAllTests).toHaveBeenCalledWith(2, undefined, 'Sanity')
+            expect(mockTestService.runAllTests).toHaveBeenCalledWith(
+                2,
+                undefined,
+                'Sanity',
+                undefined
+            )
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, runResult)
         })
 
@@ -251,7 +262,12 @@ describe('TestController', () => {
             await controller.runAllTests(mockReq as ServiceRequest, mockRes as Response)
 
             // Assert
-            expect(mockTestService.runAllTests).toHaveBeenCalledWith(4, undefined, undefined)
+            expect(mockTestService.runAllTests).toHaveBeenCalledWith(
+                4,
+                undefined,
+                undefined,
+                undefined
+            )
         })
 
         it('should handle tests already running error (409)', async () => {

--- a/packages/server/src/controllers/settings.controller.ts
+++ b/packages/server/src/controllers/settings.controller.ts
@@ -78,6 +78,78 @@ export class SettingsController {
         }
     }
 
+    getProjectTabConfigs = async (_req: ServiceRequest, res: Response): Promise<Response> => {
+        try {
+            const configs = await this.settingsService.getProjectTabConfigs()
+            return ResponseHelper.success(res, configs)
+        } catch (error) {
+            Logger.error('Error getting project tab configs', error)
+            return ResponseHelper.error(
+                res,
+                error instanceof Error ? error.message : 'Unknown error',
+                'Failed to get project tab configs',
+                500
+            )
+        }
+    }
+
+    updateProjectTabConfigs = async (req: ServiceRequest, res: Response): Promise<Response> => {
+        try {
+            const {configs} = req.body
+
+            if (!Array.isArray(configs)) {
+                return ResponseHelper.badRequest(res, 'configs must be an array')
+            }
+
+            const saved = await this.settingsService.setProjectTabConfigs(configs)
+            return ResponseHelper.success(res, saved)
+        } catch (error) {
+            Logger.error('Error updating project tab configs', error)
+            return ResponseHelper.error(
+                res,
+                error instanceof Error ? error.message : 'Unknown error',
+                'Failed to update project tab configs',
+                500
+            )
+        }
+    }
+
+    getCIAutoRunPause = async (_req: ServiceRequest, res: Response): Promise<Response> => {
+        try {
+            const pause = await this.settingsService.getCIAutoRunPause()
+            return ResponseHelper.success(res, pause)
+        } catch (error) {
+            Logger.error('Error getting CI auto-run pause', error)
+            return ResponseHelper.error(
+                res,
+                error instanceof Error ? error.message : 'Unknown error',
+                'Failed to get CI auto-run pause',
+                500
+            )
+        }
+    }
+
+    updateCIAutoRunPause = async (req: ServiceRequest, res: Response): Promise<Response> => {
+        try {
+            const {paused, durationHours} = req.body
+
+            if (typeof paused !== 'boolean') {
+                return ResponseHelper.badRequest(res, 'paused must be a boolean')
+            }
+
+            const pause = await this.settingsService.setCIAutoRunPause(paused, durationHours)
+            return ResponseHelper.success(res, pause)
+        } catch (error) {
+            Logger.error('Error updating CI auto-run pause', error)
+            return ResponseHelper.error(
+                res,
+                error instanceof Error ? error.message : 'Unknown error',
+                'Failed to update CI auto-run pause',
+                500
+            )
+        }
+    }
+
     updateGlobalPlaywrightProject = async (
         req: ServiceRequest,
         res: Response

--- a/packages/server/src/controllers/test.controller.ts
+++ b/packages/server/src/controllers/test.controller.ts
@@ -50,11 +50,12 @@ export class TestController {
     // POST /api/tests/run-all - Run all tests
     runAllTests = async (req: ServiceRequest, res: Response): Promise<void> => {
         try {
-            const {maxWorkers, skipAutoDiscovery, project} = req.body
+            const {maxWorkers, skipAutoDiscovery, project, source} = req.body
             const result = await this.testService.runAllTests(
                 maxWorkers,
                 skipAutoDiscovery,
-                project
+                project,
+                source
             )
             ResponseHelper.success(res, result)
         } catch (error) {
@@ -81,6 +82,23 @@ export class TestController {
                         'Tests are already running',
                         409
                     )
+                    return
+                }
+            }
+
+            if (error instanceof Error && error.message.includes('CI_AUTORUN_PAUSED')) {
+                try {
+                    const errorData = JSON.parse(error.message)
+                    res.status(423).json({
+                        success: false,
+                        code: errorData.code,
+                        message: errorData.message,
+                        resumeAt: errorData.resumeAt,
+                        timestamp: new Date().toISOString(),
+                    })
+                    return
+                } catch {
+                    ResponseHelper.error(res, 'CI auto-run is paused', 'CI auto-run is paused', 423)
                     return
                 }
             }
@@ -324,6 +342,7 @@ export class TestController {
                 errorMessage: testData.errorMessage || null,
                 errorStack: testData.errorStack || null,
                 retryCount: testData.retryCount || 0,
+                project: testData.project || '',
                 metadata: testData.metadata || {},
                 timestamp: testData.timestamp || new Date().toISOString(), // Use reporter's timestamp
                 attachments: testData.attachments,

--- a/packages/server/src/database/database.manager.ts
+++ b/packages/server/src/database/database.manager.ts
@@ -140,7 +140,7 @@ export class DatabaseManager {
                         reject(error)
                     } else {
                         Logger.critical('Database schema initialized successfully')
-                        resolve()
+                        this.runMigrations().then(resolve).catch(reject)
                     }
                 })
                 return
@@ -157,9 +157,55 @@ export class DatabaseManager {
                 reject(error)
             } else {
                 Logger.critical('Database schema initialized successfully')
-                resolve()
+                this.runMigrations().then(resolve).catch(reject)
             }
         })
+    }
+
+    private async runMigrations(): Promise<void> {
+        // Add project column if missing (existing DBs pre-feature)
+        try {
+            await new Promise<void>((resolve, reject) => {
+                this.db.run(
+                    `ALTER TABLE test_results ADD COLUMN project TEXT DEFAULT ''`,
+                    (err) => {
+                        if (err && !err.message.includes('duplicate column name')) {
+                            reject(err)
+                        } else {
+                            resolve()
+                        }
+                    }
+                )
+            })
+            Logger.info('Migration: project column ensured on test_results')
+        } catch (err) {
+            Logger.error('Migration: failed to add project column', err)
+            throw err
+        }
+
+        // Backfill project from test_runs.metadata for existing rows
+        try {
+            await new Promise<void>((resolve, reject) => {
+                this.db.run(
+                    `UPDATE test_results
+                     SET project = (
+                         SELECT json_extract(r.metadata, '$.project')
+                         FROM test_runs r
+                         WHERE r.id = test_results.run_id
+                           AND json_extract(r.metadata, '$.project') IS NOT NULL
+                     )
+                     WHERE (project IS NULL OR project = '')
+                       AND run_id IS NOT NULL`,
+                    (err) => {
+                        if (err) reject(err)
+                        else resolve()
+                    }
+                )
+            })
+            Logger.info('Migration: project backfill from test_runs.metadata completed')
+        } catch (err) {
+            Logger.warn('Migration: project backfill failed (non-fatal)', err)
+        }
     }
 
     // Helper method to promisify database operations
@@ -291,12 +337,14 @@ export class DatabaseManager {
     }
 
     // Test Results
-    async saveTestResult(testData: TestResultData & {timestamp?: string}): Promise<string> {
+    async saveTestResult(
+        testData: TestResultData & {timestamp?: string; project?: string}
+    ): Promise<string> {
         const timestamp = (testData as any).timestamp || new Date().toISOString()
         const insertSql = `
             INSERT INTO test_results
-            (id, run_id, test_id, name, file_path, status, duration, error_message, error_stack, retry_count, metadata, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, run_id, test_id, name, file_path, status, duration, error_message, error_stack, retry_count, project, metadata, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `
         await this.run(insertSql, [
             testData.id,
@@ -309,6 +357,7 @@ export class DatabaseManager {
             testData.errorMessage || null,
             testData.errorStack || null,
             testData.retryCount || 0,
+            (testData as any).project || '',
             testData.metadata ? JSON.stringify(testData.metadata) : null,
             timestamp, // Use timestamp from reporter (already in UTC ISO format)
             timestamp, // Set both created_at and updated_at to the same value

--- a/packages/server/src/database/schema.sql
+++ b/packages/server/src/database/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS test_results (
     error_message TEXT,
     error_stack TEXT,
     retry_count INTEGER DEFAULT 0,
+    project TEXT DEFAULT '',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     metadata TEXT -- JSON string for test steps, annotations, etc.

--- a/packages/server/src/repositories/__tests__/settings.repository.test.ts
+++ b/packages/server/src/repositories/__tests__/settings.repository.test.ts
@@ -89,4 +89,67 @@ describe('SettingsRepository', () => {
             expect(project).toBe('chromium')
         })
     })
+
+    describe('Project Tab Configs', () => {
+        it('getProjectTabConfigs returns empty array when no row exists', async () => {
+            const configs = await repository.getProjectTabConfigs()
+
+            expect(configs).toEqual([])
+        })
+
+        it('getProjectTabConfigs returns saved configs after setProjectTabConfigs', async () => {
+            const input = [
+                {project: 'Frontend', displayName: 'Frontend Tests', visible: true},
+                {project: 'Backend', displayName: 'Backend Tests', visible: false},
+            ]
+
+            await repository.setProjectTabConfigs(input)
+            const configs = await repository.getProjectTabConfigs()
+
+            expect(configs).toEqual(input)
+        })
+
+        it('setProjectTabConfigs called twice overwrites (UPSERT, not append)', async () => {
+            const first = [{project: 'Frontend', displayName: 'Frontend', visible: true}]
+            const second = [
+                {project: 'Backend', displayName: 'Backend', visible: false},
+                {project: 'Mobile', displayName: 'Mobile', visible: true},
+            ]
+
+            await repository.setProjectTabConfigs(first)
+            await repository.setProjectTabConfigs(second)
+
+            const configs = await repository.getProjectTabConfigs()
+
+            expect(configs).toHaveLength(2)
+            expect(configs).toEqual(second)
+        })
+
+        it('returns empty array and does not throw on malformed JSON in DB', async () => {
+            // Insert raw bad JSON directly to simulate corruption
+            const db = (dbManager as any).db
+            await new Promise<void>((resolve, reject) =>
+                db.run(
+                    `INSERT INTO app_settings (key, value) VALUES ('project_tab_configs', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+                    ['{not valid json['],
+                    (err: any) => (err ? reject(err) : resolve())
+                )
+            )
+
+            const configs = await repository.getProjectTabConfigs()
+
+            expect(configs).toEqual([])
+        })
+
+        it('setting tab configs does not affect global_playwright_project key', async () => {
+            await repository.setGlobalPlaywrightProject('Sanity')
+            await repository.setProjectTabConfigs([
+                {project: 'Frontend', displayName: 'FE', visible: true},
+            ])
+
+            const project = await repository.getGlobalPlaywrightProject()
+
+            expect(project).toBe('Sanity')
+        })
+    })
 })

--- a/packages/server/src/repositories/__tests__/test.repository.test.ts
+++ b/packages/server/src/repositories/__tests__/test.repository.test.ts
@@ -1468,4 +1468,48 @@ describe('TestRepository - Core Functionality', () => {
             }
         })
     })
+
+    describe('getProjectByFilePath()', () => {
+        it('should return project name for a known file path', async () => {
+            await repository.saveTestResult(
+                createTestResult('test-1', 'passed', {
+                    filePath: 'e2e/tests/staging/login.test.ts',
+                    project: 'Staging',
+                })
+            )
+
+            const project = await repository.getProjectByFilePath('e2e/tests/staging/login.test.ts')
+            expect(project).toBe('Staging')
+        })
+
+        it('should return empty string when file path has no matching records', async () => {
+            const project = await repository.getProjectByFilePath('e2e/tests/nonexistent.test.ts')
+            expect(project).toBe('')
+        })
+
+        it('should return empty string when matching records have empty project', async () => {
+            await repository.saveTestResult(
+                createTestResult('test-2', 'passed', {
+                    filePath: 'e2e/tests/general.test.ts',
+                    project: '',
+                })
+            )
+
+            const project = await repository.getProjectByFilePath('e2e/tests/general.test.ts')
+            expect(project).toBe('')
+        })
+
+        it('should return the most recent project when file has multiple executions', async () => {
+            const filePath = 'e2e/tests/budget.test.ts'
+            await repository.saveTestResult(
+                createTestResult('test-3', 'failed', {filePath, project: 'All_Tests'})
+            )
+            await repository.saveTestResult(
+                createTestResult('test-3', 'passed', {filePath, project: 'All_Tests'})
+            )
+
+            const project = await repository.getProjectByFilePath(filePath)
+            expect(project).toBe('All_Tests')
+        })
+    })
 })

--- a/packages/server/src/repositories/settings.repository.ts
+++ b/packages/server/src/repositories/settings.repository.ts
@@ -3,6 +3,9 @@ import {BaseRepository} from './base.repository'
 const GLOBAL_PLAYWRIGHT_PROJECT_KEY = 'global_playwright_project'
 const DISK_WARNING_PERCENT_KEY = 'disk_warning_threshold_percent'
 const DISK_CRITICAL_PERCENT_KEY = 'disk_critical_threshold_percent'
+const PROJECT_TAB_CONFIGS_KEY = 'project_tab_configs'
+const CI_AUTORUN_PAUSED_KEY = 'ci_autorun_paused'
+const CI_AUTORUN_RESUME_AT_KEY = 'ci_autorun_resume_at'
 
 const DISK_WARNING_DEFAULT = 20
 const DISK_CRITICAL_DEFAULT = 5
@@ -17,11 +20,26 @@ export interface DiskThresholds {
     criticalPercent: number
 }
 
+export interface ProjectTabConfig {
+    project: string
+    displayName: string
+    visible: boolean
+}
+
+export interface CIAutoRunPause {
+    paused: boolean
+    resumeAt: string | null
+}
+
 export interface ISettingsRepository {
     getGlobalPlaywrightProject(): Promise<string>
     setGlobalPlaywrightProject(project: string): Promise<void>
     getDiskThresholds(): Promise<DiskThresholds>
     setDiskThresholds(thresholds: DiskThresholds): Promise<void>
+    getProjectTabConfigs(): Promise<ProjectTabConfig[]>
+    setProjectTabConfigs(configs: ProjectTabConfig[]): Promise<void>
+    getCIAutoRunPause(): Promise<CIAutoRunPause>
+    setCIAutoRunPause(pause: CIAutoRunPause): Promise<void>
 }
 
 export class SettingsRepository extends BaseRepository implements ISettingsRepository {
@@ -78,5 +96,61 @@ export class SettingsRepository extends BaseRepository implements ISettingsRepos
             DISK_CRITICAL_PERCENT_KEY,
             String(thresholds.criticalPercent),
         ])
+    }
+
+    async getProjectTabConfigs(): Promise<ProjectTabConfig[]> {
+        const row = await this.queryOne<AppSettingRow>(
+            'SELECT key, value FROM app_settings WHERE key = ?',
+            [PROJECT_TAB_CONFIGS_KEY]
+        )
+
+        if (!row?.value) return []
+
+        try {
+            return JSON.parse(row.value) as ProjectTabConfig[]
+        } catch {
+            return []
+        }
+    }
+
+    async setProjectTabConfigs(configs: ProjectTabConfig[]): Promise<void> {
+        await this.execute(
+            `
+                INSERT INTO app_settings (key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = CURRENT_TIMESTAMP
+            `,
+            [PROJECT_TAB_CONFIGS_KEY, JSON.stringify(configs)]
+        )
+    }
+
+    async getCIAutoRunPause(): Promise<CIAutoRunPause> {
+        const [pausedRow, resumeAtRow] = await Promise.all([
+            this.queryOne<AppSettingRow>('SELECT key, value FROM app_settings WHERE key = ?', [
+                CI_AUTORUN_PAUSED_KEY,
+            ]),
+            this.queryOne<AppSettingRow>('SELECT key, value FROM app_settings WHERE key = ?', [
+                CI_AUTORUN_RESUME_AT_KEY,
+            ]),
+        ])
+
+        return {
+            paused: pausedRow?.value === 'true',
+            resumeAt: resumeAtRow?.value ?? null,
+        }
+    }
+
+    async setCIAutoRunPause(pause: CIAutoRunPause): Promise<void> {
+        const upsertSql = `
+            INSERT INTO app_settings (key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = CURRENT_TIMESTAMP
+        `
+        await this.execute(upsertSql, [CI_AUTORUN_PAUSED_KEY, pause.paused ? 'true' : 'false'])
+        await this.execute(upsertSql, [CI_AUTORUN_RESUME_AT_KEY, pause.resumeAt ?? ''])
     }
 }

--- a/packages/server/src/repositories/test.repository.ts
+++ b/packages/server/src/repositories/test.repository.ts
@@ -185,6 +185,14 @@ export class TestRepository extends BaseRepository implements ITestRepository {
         return this.dbManager.getDataStats()
     }
 
+    async getProjectByFilePath(filePath: string): Promise<string> {
+        const row = await this.queryOne<{project: string}>(
+            `SELECT project FROM test_results WHERE file_path = ? AND project != '' ORDER BY updated_at DESC LIMIT 1`,
+            [filePath]
+        )
+        return row?.project ?? ''
+    }
+
     async getFlakyTests(days: number = 30, thresholdPercent: number = 10): Promise<any[]> {
         const sql = `
             SELECT
@@ -392,6 +400,7 @@ export class TestRepository extends BaseRepository implements ITestRepository {
             errorMessage: row.error_message,
             errorStack: row.error_stack,
             retryCount: row.retry_count,
+            project: row.project || '',
             metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
             timestamp: row.created_at,
             createdAt: row.created_at,

--- a/packages/server/src/routes/settings.routes.ts
+++ b/packages/server/src/routes/settings.routes.ts
@@ -14,6 +14,10 @@ export function createSettingsRoutes(container: ServiceContainer): Router {
     router.put('/test-execution/project', settingsController.updateGlobalPlaywrightProject)
     router.get('/disk-thresholds', settingsController.getDiskThresholds)
     router.put('/disk-thresholds', settingsController.updateDiskThresholds)
+    router.get('/project-tabs', settingsController.getProjectTabConfigs)
+    router.put('/project-tabs', settingsController.updateProjectTabConfigs)
+    router.get('/ci-autorun-pause', settingsController.getCIAutoRunPause)
+    router.put('/ci-autorun-pause', settingsController.updateCIAutoRunPause)
 
     return router
 }

--- a/packages/server/src/services/__tests__/playwright.service.test.ts
+++ b/packages/server/src/services/__tests__/playwright.service.test.ts
@@ -267,6 +267,86 @@ describe('PlaywrightService', () => {
             )
         })
 
+        it('should extract project from spec.tests[0].projectName', async () => {
+            // Arrange
+            const mockPlaywrightOutput = {
+                suites: [
+                    {
+                        specs: [
+                            {
+                                title: 'login test',
+                                file: 'auth.spec.ts',
+                                line: 1,
+                                tests: [{projectName: 'Frontend'}],
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            mockSpawn.mockReturnValue(createMockProcess(JSON.stringify(mockPlaywrightOutput)))
+
+            // Act
+            const tests = await service.discoverTests()
+
+            // Assert
+            expect(tests).toHaveLength(1)
+            expect(tests[0].project).toBe('Frontend')
+        })
+
+        it('should set project to empty string when spec.tests is empty array', async () => {
+            // Arrange
+            const mockPlaywrightOutput = {
+                suites: [
+                    {
+                        specs: [
+                            {
+                                title: 'no-project test',
+                                file: 'test.spec.ts',
+                                line: 1,
+                                tests: [],
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            mockSpawn.mockReturnValue(createMockProcess(JSON.stringify(mockPlaywrightOutput)))
+
+            // Act
+            const tests = await service.discoverTests()
+
+            // Assert
+            expect(tests).toHaveLength(1)
+            expect(tests[0].project).toBe('')
+        })
+
+        it('should set project to empty string when spec has no tests field', async () => {
+            // Arrange
+            const mockPlaywrightOutput = {
+                suites: [
+                    {
+                        specs: [
+                            {
+                                title: 'test without tests field',
+                                file: 'test.spec.ts',
+                                line: 1,
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            mockSpawn.mockReturnValue(createMockProcess(JSON.stringify(mockPlaywrightOutput)))
+
+            // Act
+            const tests = await service.discoverTests()
+
+            // Assert
+            expect(tests).toHaveLength(1)
+            expect(tests[0].project).toBe('')
+        })
+
         it('should handle process spawn error', async () => {
             // Arrange
             const mockProcess = new EventEmitter() as ChildProcess & {

--- a/packages/server/src/services/__tests__/settings.service.test.ts
+++ b/packages/server/src/services/__tests__/settings.service.test.ts
@@ -18,6 +18,8 @@ describe('SettingsService', () => {
         setGlobalPlaywrightProject: Mock
         getDiskThresholds: Mock
         setDiskThresholds: Mock
+        getProjectTabConfigs: Mock
+        setProjectTabConfigs: Mock
     }
     let mockPlaywrightService: {
         getAvailableProjects: Mock
@@ -34,6 +36,8 @@ describe('SettingsService', () => {
             setGlobalPlaywrightProject: vi.fn(),
             getDiskThresholds: vi.fn(),
             setDiskThresholds: vi.fn(),
+            getProjectTabConfigs: vi.fn(),
+            setProjectTabConfigs: vi.fn(),
         }
         mockPlaywrightService = {
             getAvailableProjects: vi.fn(),
@@ -118,6 +122,53 @@ describe('SettingsService', () => {
             const result = await service.setDiskThresholds(2, 1)
 
             expect(result).toEqual({warningPercent: 2, criticalPercent: 1})
+        })
+    })
+
+    describe('setProjectTabConfigs normalization', () => {
+        it('should fall back displayName to project value when displayName is absent (empty string)', async () => {
+            mockRepository.setProjectTabConfigs.mockResolvedValue(undefined)
+
+            const result = await service.setProjectTabConfigs([
+                {project: 'Frontend', displayName: '', visible: true},
+            ])
+
+            expect(result[0].displayName).toBe('Frontend')
+            expect(result[0].project).toBe('Frontend')
+        })
+
+        it('should trim whitespace from project field', async () => {
+            mockRepository.setProjectTabConfigs.mockResolvedValue(undefined)
+
+            const result = await service.setProjectTabConfigs([
+                {project: '  Backend  ', displayName: 'Backend Tests', visible: true},
+            ])
+
+            expect(result[0].project).toBe('Backend')
+        })
+
+        it('should coerce truthy non-boolean visible to boolean true', async () => {
+            mockRepository.setProjectTabConfigs.mockResolvedValue(undefined)
+
+            const input = [
+                {project: 'A', displayName: 'A', visible: 'true' as any},
+                {project: 'B', displayName: 'B', visible: 1 as any},
+            ]
+            const result = await service.setProjectTabConfigs(input)
+
+            expect(result[0].visible).toBe(true)
+            expect(typeof result[0].visible).toBe('boolean')
+            expect(result[1].visible).toBe(true)
+            expect(typeof result[1].visible).toBe('boolean')
+        })
+
+        it('should persist empty array without error', async () => {
+            mockRepository.setProjectTabConfigs.mockResolvedValue(undefined)
+
+            const result = await service.setProjectTabConfigs([])
+
+            expect(result).toEqual([])
+            expect(mockRepository.setProjectTabConfigs).toHaveBeenCalledWith([])
         })
     })
 })

--- a/packages/server/src/services/__tests__/test.service.test.ts
+++ b/packages/server/src/services/__tests__/test.service.test.ts
@@ -82,6 +82,7 @@ describe('TestService', () => {
             getStrippableIdsByCount: vi.fn(),
             getAttachmentsSizeForIds: vi.fn().mockResolvedValue({total: 0, perId: {}}),
             deleteByIds: vi.fn().mockResolvedValue(0),
+            getProjectByFilePath: vi.fn().mockResolvedValue(''),
         }
 
         mockRunRepository = {
@@ -369,6 +370,103 @@ describe('TestService', () => {
                 'exec-1',
                 []
             )
+        })
+
+        describe('project fallback from run metadata', () => {
+            it('should backfill project from run metadata when project is empty and runId present', async () => {
+                const testData: any = {
+                    id: 'exec-1',
+                    testId: 'hash-1',
+                    runId: 'run-1',
+                    name: 'Test 1',
+                    filePath: '/path/to/test.spec.ts',
+                    status: 'passed',
+                    duration: 100,
+                    metadata: '{}',
+                    timestamp: '2025-10-21T10:00:00.000Z',
+                }
+
+                mockRunRepository.getTestRun.mockResolvedValue({
+                    id: 'run-1',
+                    status: 'running',
+                    metadata: {project: 'Frontend'},
+                })
+                mockTestRepository.saveTestResult.mockResolvedValue('exec-1')
+
+                await testService.saveTestResult(testData)
+
+                expect(mockRunRepository.getTestRun).toHaveBeenCalledTimes(1)
+                expect(mockRunRepository.getTestRun).toHaveBeenCalledWith('run-1')
+                expect(testData.project).toBe('Frontend')
+                expect(mockTestRepository.saveTestResult).toHaveBeenCalledWith(testData)
+            })
+
+            it('should leave project empty when run has no metadata.project', async () => {
+                const testData: any = {
+                    id: 'exec-2',
+                    testId: 'hash-2',
+                    runId: 'run-2',
+                    name: 'Test 2',
+                    filePath: '/path/to/test.spec.ts',
+                    status: 'passed',
+                    duration: 100,
+                    metadata: '{}',
+                    timestamp: '2025-10-21T10:00:00.000Z',
+                }
+
+                mockRunRepository.getTestRun.mockResolvedValue({
+                    id: 'run-2',
+                    status: 'running',
+                    metadata: {},
+                })
+                mockTestRepository.saveTestResult.mockResolvedValue('exec-2')
+
+                await expect(testService.saveTestResult(testData)).resolves.toBe('exec-2')
+                expect(mockRunRepository.getTestRun).toHaveBeenCalledTimes(1)
+                expect(testData.project).toBeUndefined()
+            })
+
+            it('should NOT call getTestRun when project is empty and runId is absent', async () => {
+                const testData: any = {
+                    id: 'exec-3',
+                    testId: 'hash-3',
+                    runId: null,
+                    name: 'Test 3',
+                    filePath: '/path/to/test.spec.ts',
+                    status: 'passed',
+                    duration: 100,
+                    metadata: '{}',
+                    timestamp: '2025-10-21T10:00:00.000Z',
+                }
+
+                mockTestRepository.saveTestResult.mockResolvedValue('exec-3')
+
+                await testService.saveTestResult(testData)
+
+                expect(mockRunRepository.getTestRun).not.toHaveBeenCalled()
+            })
+
+            it('should NOT call getTestRun when project is already set', async () => {
+                const testData: any = {
+                    id: 'exec-4',
+                    testId: 'hash-4',
+                    runId: 'run-4',
+                    project: 'Backend',
+                    name: 'Test 4',
+                    filePath: '/path/to/test.spec.ts',
+                    status: 'passed',
+                    duration: 100,
+                    metadata: '{}',
+                    timestamp: '2025-10-21T10:00:00.000Z',
+                }
+
+                mockTestRepository.saveTestResult.mockResolvedValue('exec-4')
+
+                await testService.saveTestResult(testData)
+
+                expect(mockRunRepository.getTestRun).not.toHaveBeenCalled()
+                expect(testData.project).toBe('Backend')
+            })
         })
     })
 
@@ -692,22 +790,41 @@ describe('TestService', () => {
             )
         })
 
-        it('should use global project from settings service', async () => {
+        it('should use requestedProject when provided, ignoring global settings', async () => {
             // Arrange
             const mockProcess = createMockProcess()
             mockSettingsService.getGlobalPlaywrightProject.mockResolvedValue('Sanity')
             mockPlaywrightService.runAllTests.mockResolvedValue({
                 runId: 'run-proj-1',
-                message: 'Tests started for project: Sanity',
+                message: 'Tests started for project: Frontend',
                 timestamp: '2025-10-21T10:00:00.000Z',
                 process: mockProcess,
             })
             mockRunRepository.createTestRun.mockResolvedValue('run-proj-1')
 
             // Act
-            await testService.runAllTests(2, false, 'Ignored_By_Request')
+            await testService.runAllTests(2, false, 'Frontend')
 
-            // Assert - project resolved from global settings
+            // Assert - requestedProject takes precedence over global settings
+            expect(mockPlaywrightService.runAllTests).toHaveBeenCalledWith(2, 'Frontend')
+        })
+
+        it('should fall back to global project from settings when no requestedProject', async () => {
+            // Arrange
+            const mockProcess = createMockProcess()
+            mockSettingsService.getGlobalPlaywrightProject.mockResolvedValue('Sanity')
+            mockPlaywrightService.runAllTests.mockResolvedValue({
+                runId: 'run-proj-2',
+                message: 'Tests started for project: Sanity',
+                timestamp: '2025-10-21T10:00:00.000Z',
+                process: mockProcess,
+            })
+            mockRunRepository.createTestRun.mockResolvedValue('run-proj-2')
+
+            // Act
+            await testService.runAllTests(2)
+
+            // Assert - global settings used as fallback
             expect(mockPlaywrightService.runAllTests).toHaveBeenCalledWith(2, 'Sanity')
         })
 
@@ -902,6 +1019,30 @@ describe('TestService', () => {
             )
         })
 
+        it('should use project from getProjectByFilePath when available', async () => {
+            const mockProcess = createMockProcess()
+            const mockResult = {
+                runId: 'run-456',
+                message: 'Group tests started',
+                timestamp: '2025-10-21T10:00:00.000Z',
+                process: mockProcess,
+            }
+
+            mockTestRepository.getProjectByFilePath.mockResolvedValue('Staging')
+            mockPlaywrightService.runTestGroup.mockResolvedValue(mockResult)
+            mockRunRepository.createTestRun.mockResolvedValue('run-456')
+
+            await testService.runTestGroup('/path/to/staging.spec.ts', 2)
+
+            expect(mockPlaywrightService.runTestGroup).toHaveBeenCalledWith(
+                '/path/to/staging.spec.ts',
+                2,
+                undefined,
+                'Staging'
+            )
+            expect(mockSettingsService.getGlobalPlaywrightProject).not.toHaveBeenCalled()
+        })
+
         it('should handle group process completion', async () => {
             const mockProcess = createMockProcess()
             const mockResult = {
@@ -983,6 +1124,38 @@ describe('TestService', () => {
                     project: 'All_Tests',
                 },
             })
+        })
+
+        it('should use test.project from DB record instead of global setting', async () => {
+            const mockTest = {
+                id: 'exec-1',
+                testId: 'hash-1',
+                name: 'Test 1',
+                filePath: '/path/to/staging.spec.ts',
+                status: 'failed',
+                project: 'Staging',
+            }
+            const mockProcess = createMockProcess()
+            const mockResult = {
+                runId: 'rerun-789',
+                message: 'Test rerun started',
+                timestamp: '2025-10-21T10:00:00.000Z',
+                process: mockProcess,
+            }
+
+            mockTestRepository.getTestResult.mockResolvedValue(mockTest)
+            mockPlaywrightService.rerunSingleTest.mockResolvedValue(mockResult)
+            mockRunRepository.createTestRun.mockResolvedValue('rerun-789')
+
+            await testService.rerunTest('exec-1', 1)
+
+            expect(mockPlaywrightService.rerunSingleTest).toHaveBeenCalledWith(
+                '/path/to/staging.spec.ts',
+                'Test 1',
+                1,
+                'Staging'
+            )
+            expect(mockSettingsService.getGlobalPlaywrightProject).not.toHaveBeenCalled()
         })
 
         it('should throw error if test not found', async () => {

--- a/packages/server/src/services/playwright.service.ts
+++ b/packages/server/src/services/playwright.service.ts
@@ -34,7 +34,8 @@ export class PlaywrightService implements IPlaywrightService {
 
         const discoveredTests: DiscoveredTest[] = []
 
-        // Extract all tests from both top-level and nested structures
+        // Extract all tests from both top-level and nested structures.
+        // Project comes from spec.tests[0].projectName (Playwright JSON reporter field).
         for (const suite of playwrightData.suites || []) {
             // Handle top-level specs directly under the suite
             for (const spec of suite.specs || []) {
@@ -81,6 +82,7 @@ export class PlaywrightService implements IPlaywrightService {
             type: 'run-all',
             env: {
                 RUN_ID: runId,
+                PLAYWRIGHT_PROJECT: project || '',
             },
         })
 
@@ -128,6 +130,7 @@ export class PlaywrightService implements IPlaywrightService {
             filePath,
             env: {
                 RUN_ID: runId,
+                PLAYWRIGHT_PROJECT: project || '',
             },
         })
 
@@ -172,6 +175,7 @@ export class PlaywrightService implements IPlaywrightService {
             env: {
                 RERUN_MODE: 'true',
                 RERUN_ID: runId,
+                PLAYWRIGHT_PROJECT: project || '',
             },
         })
 
@@ -314,6 +318,8 @@ export class PlaywrightService implements IPlaywrightService {
         // Use file path directly from Playwright - it handles path resolution based on testDir
         const filePath = spec.file
         const stableTestId = this.generateStableTestId(filePath, spec.title)
+        // Project comes from the first test entry's projectName (Playwright JSON reporter)
+        const project = spec.tests?.[0]?.projectName || ''
 
         return {
             id: uuidv4(),
@@ -323,6 +329,7 @@ export class PlaywrightService implements IPlaywrightService {
             filePath: filePath,
             status: 'pending',
             duration: 0,
+            project,
             metadata: JSON.stringify({
                 line: spec.line || 0,
                 playwrightId: spec.id || null,

--- a/packages/server/src/services/settings.service.ts
+++ b/packages/server/src/services/settings.service.ts
@@ -1,4 +1,9 @@
-import {SettingsRepository, DiskThresholds} from '../repositories/settings.repository'
+import {
+    SettingsRepository,
+    DiskThresholds,
+    ProjectTabConfig,
+    CIAutoRunPause,
+} from '../repositories/settings.repository'
 import {PlaywrightService} from './playwright.service'
 import {Logger} from '../utils/logger.util'
 
@@ -6,7 +11,7 @@ export interface TestExecutionSettings {
     project: string
 }
 
-export type {DiskThresholds}
+export type {DiskThresholds, ProjectTabConfig, CIAutoRunPause}
 
 export class SettingsService {
     constructor(
@@ -55,6 +60,44 @@ export class SettingsService {
             `Disk thresholds updated: warning=${warningPercent}%, critical=${criticalPercent}%`
         )
         return thresholds
+    }
+
+    async getProjectTabConfigs(): Promise<ProjectTabConfig[]> {
+        return this.settingsRepository.getProjectTabConfigs()
+    }
+
+    async setProjectTabConfigs(configs: ProjectTabConfig[]): Promise<ProjectTabConfig[]> {
+        const validated = configs.map((c) => ({
+            project: String(c.project || '').trim(),
+            displayName: String(c.displayName || c.project || '').trim(),
+            visible: Boolean(c.visible),
+        }))
+        await this.settingsRepository.setProjectTabConfigs(validated)
+        Logger.info(`Project tab configs updated: ${validated.length} entries`)
+        return validated
+    }
+
+    async getCIAutoRunPause(): Promise<CIAutoRunPause> {
+        return this.settingsRepository.getCIAutoRunPause()
+    }
+
+    async setCIAutoRunPause(paused: boolean, durationHours?: number): Promise<CIAutoRunPause> {
+        let resumeAt: string | null = null
+
+        if (paused && durationHours && durationHours > 0) {
+            const resume = new Date()
+            resume.setHours(resume.getHours() + durationHours)
+            resumeAt = resume.toISOString()
+        }
+
+        const pause: CIAutoRunPause = {paused, resumeAt}
+        await this.settingsRepository.setCIAutoRunPause(pause)
+        Logger.info(
+            paused
+                ? `CI auto-run paused${resumeAt ? ` until ${resumeAt}` : ' indefinitely'}`
+                : 'CI auto-run resumed'
+        )
+        return pause
     }
 
     async setGlobalPlaywrightProject(project: string): Promise<TestExecutionSettings> {

--- a/packages/server/src/services/test.service.ts
+++ b/packages/server/src/services/test.service.ts
@@ -266,6 +266,14 @@ export class TestService implements ITestService {
     }
 
     async saveTestResult(testData: TestResultData): Promise<string> {
+        // If reporter didn't send project, fall back to the run's metadata.project
+        if (!(testData as any).project && testData.runId) {
+            const run = await this.runRepository.getTestRun(testData.runId)
+            if (run?.metadata?.project) {
+                ;(testData as any).project = run.metadata.project
+            }
+        }
+
         const resultId = await this.testRepository.saveTestResult(testData)
 
         // Save attachments if provided
@@ -298,8 +306,28 @@ export class TestService implements ITestService {
     async runAllTests(
         maxWorkers?: number,
         skipAutoDiscovery?: boolean,
-        _project?: string
+        requestedProject?: string,
+        source?: string
     ): Promise<any> {
+        // Block CI script triggers when paused
+        if (source === 'script') {
+            const pause = await this.settingsService.getCIAutoRunPause()
+            if (pause.paused) {
+                if (pause.resumeAt && new Date(pause.resumeAt) <= new Date()) {
+                    // Auto-resume: time has passed
+                    await this.settingsService.setCIAutoRunPause(false)
+                } else {
+                    throw new Error(
+                        JSON.stringify({
+                            code: 'CI_AUTORUN_PAUSED',
+                            message: 'CI auto-run is paused',
+                            resumeAt: pause.resumeAt,
+                        })
+                    )
+                }
+            }
+        }
+
         // Check if tests are already running
         if (activeProcessesTracker.isRunAllActive()) {
             const activeRuns = activeProcessesTracker.getActiveProcesses()
@@ -329,7 +357,10 @@ export class TestService implements ITestService {
             await this.discoverTests()
         }
 
-        const project = await this.getExecutionProject()
+        const project =
+            requestedProject !== undefined && requestedProject !== ''
+                ? requestedProject
+                : await this.getExecutionProject()
         const result = await this.playwrightService.runAllTests(maxWorkers, project)
 
         // Add process to tracker
@@ -377,7 +408,8 @@ export class TestService implements ITestService {
     }
 
     async runTestGroup(filePath: string, maxWorkers?: number, testNames?: string[]): Promise<any> {
-        const project = await this.getExecutionProject()
+        const projectFromFile = await this.testRepository.getProjectByFilePath(filePath)
+        const project = projectFromFile || (await this.getExecutionProject())
         const result = await this.playwrightService.runTestGroup(
             filePath,
             maxWorkers,
@@ -443,7 +475,7 @@ export class TestService implements ITestService {
             throw new Error('Test not found')
         }
 
-        const project = await this.getExecutionProject()
+        const project = test.project || (await this.getExecutionProject())
         const result = await this.playwrightService.rerunSingleTest(
             test.filePath,
             test.name,

--- a/packages/server/src/types/database.types.ts
+++ b/packages/server/src/types/database.types.ts
@@ -28,6 +28,7 @@ export interface TestResultData {
     // ISO timestamp when this execution's attachments were stripped to free disk
     // space (history kept). Undefined means attachments were never purged.
     attachmentsClearedAt?: string
+    project?: string
 }
 
 export interface AttachmentData {
@@ -70,6 +71,7 @@ export interface TestResultRow {
     note_updated_at?: string
     // Joined attachment_cleanups field
     attachments_cleared_at?: string
+    project?: string
 }
 
 // Discovered test from Playwright
@@ -84,6 +86,7 @@ export interface DiscoveredTest {
     errorMessage?: undefined
     errorStack?: undefined
     retryCount: number
+    project?: string
     metadata: string
     timestamp: string
 }

--- a/packages/server/src/types/playwright.types.ts
+++ b/packages/server/src/types/playwright.types.ts
@@ -2,14 +2,21 @@
  * TypeScript interfaces for Playwright test discovery and execution
  */
 
+export interface PlaywrightTestEntry {
+    projectId?: string
+    projectName?: string
+}
+
 export interface PlaywrightSpec {
     id?: string
     title: string
     file: string
     line?: number
+    tests?: PlaywrightTestEntry[]
 }
 
 export interface PlaywrightSuite {
+    title?: string
     specs?: PlaywrightSpec[]
     suites?: PlaywrightSuite[]
 }

--- a/packages/server/src/types/service.types.ts
+++ b/packages/server/src/types/service.types.ts
@@ -116,6 +116,7 @@ export interface DiscoveredTest {
     filePath: string
     status: 'pending'
     duration: number
+    project?: string
     metadata: string
     timestamp: string
 }
@@ -144,6 +145,7 @@ export interface ITestRepository {
     getStrippableIdsByCount(keepCount: number): Promise<string[]>
     getAttachmentsSizeForIds(ids: string[]): Promise<{total: number; perId: Record<string, number>}>
     deleteByIds(ids: string[]): Promise<number>
+    getProjectByFilePath(filePath: string): Promise<string>
 }
 
 export interface IRunRepository {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,17 +5,18 @@ import {Header} from '@shared/components'
 import {Dashboard} from '@features/dashboard'
 import {SettingsModal} from '@features/dashboard/components/settings'
 import {DiskSpaceWarningBanner} from '@features/dashboard/components/DiskSpaceWarningBanner'
+import {CIAutoRunPauseBanner} from '@features/dashboard/components/CIAutoRunPauseBanner'
 import {useDiskSpaceWarning} from '@features/dashboard/hooks'
+import {useCIAutoRun} from '@/hooks/useCIAutoRun'
 import {TestsList} from '@features/tests'
 import {FloatingProgressPanel} from '@features/tests/components/progress/FloatingProgressPanel'
 import {LoginPage, setGlobalLogout} from '@features/authentication'
 import {useTestsStore} from '@features/tests/store/testsStore'
+import {useProjectTabs} from '@/hooks/useProjectTabs'
 import {VERSION} from '@/config/version'
 import {useWebSocket} from './hooks/useWebSocket'
 import {config} from '@config/environment.config'
 import {verifyToken} from '@features/authentication/utils/tokenValidator'
-
-type ViewMode = 'dashboard' | 'tests'
 
 function App() {
     const location = useLocation()
@@ -28,14 +29,21 @@ function App() {
 
     const {severity, diskStats, thresholds, isDismissed, dismiss, triggerCheck} =
         useDiskSpaceWarning()
+    const {pause: ciPause, resume: resumeCIAutoRun, reload: reloadCIAutoRun} = useCIAutoRun()
 
     const handleOpenSettingsToDataRetention = useCallback(() => {
         setSettingsScrollToDataRetention(true)
         setIsSettingsOpen(true)
     }, [])
 
-    // Determine current view from URL
-    const currentView: ViewMode = location.pathname.includes('/dashboard') ? 'dashboard' : 'tests'
+    // Active project from URL query param
+    const activeProject = useMemo(() => {
+        const params = new URLSearchParams(location.search)
+        return params.get('project') || ''
+    }, [location.search])
+
+    const {visibleTabs, isLoading: tabsLoading} = useProjectTabs()
+
     const {
         fetchTests,
         isLoading: testsLoading,
@@ -248,10 +256,9 @@ function App() {
     return (
         <div className="flex flex-col h-screen bg-gray-50 dark:bg-gray-950">
             <Header
-                currentView={currentView}
-                onViewChange={() => {
-                    // View change is handled by navigation in Header component
-                }}
+                activeProject={activeProject}
+                projectTabs={visibleTabs}
+                tabsLoading={tabsLoading}
                 wsConnected={isConnected}
                 onOpenSettings={() => setIsSettingsOpen(true)}
                 user={() => {
@@ -271,9 +278,14 @@ function App() {
                 onClose={() => {
                     setIsSettingsOpen(false)
                     setSettingsScrollToDataRetention(false)
+                    void reloadCIAutoRun()
                 }}
                 scrollToDataRetention={settingsScrollToDataRetention}
             />
+
+            {ciPause?.paused && (
+                <CIAutoRunPauseBanner resumeAt={ciPause.resumeAt} onResume={resumeCIAutoRun} />
+            )}
 
             {severity && !isDismissed && diskStats && thresholds && (
                 <DiskSpaceWarningBanner
@@ -296,6 +308,7 @@ function App() {
                                 onTestRerun={handleTestRerun}
                                 selectedTest={selectedTest}
                                 loading={testsLoading}
+                                activeProject={activeProject}
                             />
                         }
                     />

--- a/packages/web/src/features/dashboard/components/CIAutoRunPauseBanner.tsx
+++ b/packages/web/src/features/dashboard/components/CIAutoRunPauseBanner.tsx
@@ -1,0 +1,63 @@
+import {useEffect, useState} from 'react'
+import {PauseCircle} from 'lucide-react'
+
+interface CIAutoRunPauseBannerProps {
+    resumeAt: string | null
+    onResume: () => void
+}
+
+function formatCountdown(resumeAt: string): string {
+    const ms = new Date(resumeAt).getTime() - Date.now()
+    if (ms <= 0) return ''
+    const totalMinutes = Math.floor(ms / 60000)
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    if (hours > 0) return `${hours}h ${minutes}m`
+    return `${minutes}m`
+}
+
+export function CIAutoRunPauseBanner({resumeAt, onResume}: CIAutoRunPauseBannerProps) {
+    const [countdown, setCountdown] = useState(() => (resumeAt ? formatCountdown(resumeAt) : ''))
+
+    useEffect(() => {
+        if (!resumeAt) return
+        const interval = setInterval(() => {
+            const remaining = formatCountdown(resumeAt)
+            if (!remaining) {
+                onResume()
+                return
+            }
+            setCountdown(remaining)
+        }, 60000)
+        return () => clearInterval(interval)
+    }, [resumeAt, onResume])
+
+    return (
+        <div className="border-b border-warning-200/70 bg-warning-50 dark:border-warning-400/20 dark:bg-warning-500/10">
+            <div className="container mx-auto px-3 md:px-4 py-2">
+                <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                        <PauseCircle className="h-4 w-4 flex-shrink-0 text-warning-600 dark:text-warning-400" />
+                        <p className="text-sm font-medium text-warning-800 dark:text-warning-200 truncate">
+                            CI auto-run paused
+                            {resumeAt && countdown ? (
+                                <span className="font-normal text-warning-700 dark:text-warning-300">
+                                    {' · '}Resumes in {countdown}
+                                </span>
+                            ) : (
+                                <span className="font-normal text-warning-700 dark:text-warning-300">
+                                    {' · '}No auto-resume scheduled
+                                </span>
+                            )}
+                        </p>
+                    </div>
+                    <button
+                        onClick={onResume}
+                        className="flex-shrink-0 rounded-lg border border-warning-300 bg-warning-100 px-3 py-1 text-xs font-semibold text-warning-800 transition-colors hover:bg-warning-200 dark:border-warning-400/30 dark:bg-warning-500/20 dark:text-warning-200 dark:hover:bg-warning-500/30">
+                        Resume now
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/web/src/features/dashboard/components/settings/SettingsModal.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsModal.tsx
@@ -3,6 +3,7 @@ import {X} from 'lucide-react'
 import {ModalBackdrop} from '@shared/components/molecules'
 import {SettingsThemeSection} from './SettingsThemeSection'
 import {SettingsTestExecutionSection} from './SettingsTestExecutionSection'
+import {SettingsProjectTabsSection} from './SettingsProjectTabsSection'
 import {SettingsActionsSection} from './SettingsActionsSection'
 import {SettingsStorageSection} from './SettingsStorageSection'
 
@@ -50,6 +51,7 @@ export function SettingsModal({isOpen, onClose, scrollToDataRetention}: Settings
 
                     <div className="p-5 space-y-4 max-h-[calc(100vh-200px)] overflow-y-auto md:p-6 md:space-y-5">
                         <SettingsThemeSection />
+                        <SettingsProjectTabsSection />
                         <SettingsTestExecutionSection />
                         <SettingsActionsSection />
                         <div ref={dataRetentionRef}>

--- a/packages/web/src/features/dashboard/components/settings/SettingsProjectTabsSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsProjectTabsSection.tsx
@@ -1,0 +1,142 @@
+import {useState, useEffect} from 'react'
+import {RefreshCw} from 'lucide-react'
+import {useProjectTabs, ProjectTabConfig} from '@/hooks/useProjectTabs'
+import {SettingsSection} from './SettingsSection'
+
+export function SettingsProjectTabsSection() {
+    const {tabs, updateTabs, isLoading, isSaving, error, reload} = useProjectTabs()
+    const [localTabs, setLocalTabs] = useState<ProjectTabConfig[]>([])
+
+    // Sync local state when tabs load
+    useEffect(() => {
+        setLocalTabs(tabs)
+    }, [tabs])
+
+    const handleDisplayNameChange = (project: string, displayName: string) => {
+        setLocalTabs((prev) => prev.map((t) => (t.project === project ? {...t, displayName} : t)))
+    }
+
+    const handleDisplayNameBlur = async (project: string) => {
+        const tab = localTabs.find((t) => t.project === project)
+        if (!tab) return
+        const trimmed = tab.displayName.trim()
+        if (!trimmed) {
+            // Reset to project name if empty
+            setLocalTabs((prev) =>
+                prev.map((t) => (t.project === project ? {...t, displayName: project} : t))
+            )
+            return
+        }
+        const updated = localTabs.map((t) =>
+            t.project === project ? {...t, displayName: trimmed} : t
+        )
+        setLocalTabs(updated)
+        await updateTabs(updated)
+    }
+
+    const handleVisibleToggle = async (project: string) => {
+        const updated = localTabs.map((t) =>
+            t.project === project ? {...t, visible: !t.visible} : t
+        )
+        setLocalTabs(updated)
+        await updateTabs(updated)
+    }
+
+    const compactInputClass =
+        'rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-sm text-gray-900 ' +
+        'focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500/60 ' +
+        'dark:border-white/10 dark:bg-white/[0.05] dark:text-gray-100 w-40'
+
+    return (
+        <SettingsSection
+            title="Project Tabs"
+            description="Configure which Playwright projects appear as navigation tabs">
+            <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                    <button
+                        onClick={reload}
+                        disabled={isLoading || isSaving}
+                        className="flex items-center gap-1.5 text-xs font-medium text-gray-500 transition-colors hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400 disabled:opacity-50">
+                        <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+                        {isLoading ? 'Loading…' : 'Refresh projects'}
+                    </button>
+                    {isSaving && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500">Saving…</span>
+                    )}
+                </div>
+
+                {error && <p className="text-sm text-danger-600 dark:text-danger-400">{error}</p>}
+
+                {localTabs.length === 0 && !isLoading && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                        No Playwright projects found. Run tests first or check your
+                        playwright.config.ts.
+                    </p>
+                )}
+
+                {localTabs.length > 0 && (
+                    <div className="space-y-2">
+                        {/* Header row */}
+                        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-3 px-1">
+                            <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
+                                Project
+                            </span>
+                            <span className="text-xs font-medium text-gray-400 dark:text-gray-500 w-40">
+                                Tab label
+                            </span>
+                            <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
+                                Visible
+                            </span>
+                        </div>
+
+                        {localTabs.map((tab) => (
+                            <div
+                                key={tab.project}
+                                className="grid grid-cols-[1fr_auto_auto] items-center gap-x-3 rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 dark:border-white/[0.06] dark:bg-white/[0.02]">
+                                <span className="text-sm text-gray-700 dark:text-gray-300 truncate font-mono text-xs">
+                                    {tab.project}
+                                </span>
+                                <input
+                                    type="text"
+                                    value={tab.displayName}
+                                    onChange={(e) =>
+                                        handleDisplayNameChange(tab.project, e.target.value)
+                                    }
+                                    onBlur={() => handleDisplayNameBlur(tab.project)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            e.currentTarget.blur()
+                                        }
+                                    }}
+                                    className={compactInputClass}
+                                    disabled={isSaving}
+                                />
+                                <button
+                                    role="switch"
+                                    aria-checked={tab.visible}
+                                    onClick={() => handleVisibleToggle(tab.project)}
+                                    disabled={isSaving}
+                                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 disabled:opacity-50 ${
+                                        tab.visible
+                                            ? 'bg-primary-600 dark:bg-primary-500'
+                                            : 'bg-gray-200 dark:bg-white/10'
+                                    }`}>
+                                    <span
+                                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-soft transition-transform duration-200 ${
+                                            tab.visible ? 'translate-x-6' : 'translate-x-1'
+                                        }`}
+                                    />
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                <p className="text-xs text-gray-400 dark:text-gray-500">
+                    Changes apply globally for all users. Tab label can be renamed without affecting
+                    which project it tracks.
+                </p>
+            </div>
+        </SettingsSection>
+    )
+}

--- a/packages/web/src/features/dashboard/components/settings/SettingsTestExecutionSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsTestExecutionSection.tsx
@@ -1,7 +1,20 @@
 import {usePlaywrightWorkers} from '@/hooks/usePlaywrightWorkers'
 import {useAutoDiscoverSetting} from '@/hooks/useAutoDiscoverSetting'
 import {usePlaywrightProject} from '@/hooks/usePlaywrightProject'
+import {useCIAutoRun} from '@/hooks/useCIAutoRun'
 import {SettingsSection} from './SettingsSection'
+
+const DURATION_OPTIONS = [
+    {label: '1h', hours: 1},
+    {label: '2h', hours: 2},
+    {label: '3h', hours: 3},
+    {label: '8h', hours: 8},
+]
+
+function formatResumeTime(resumeAt: string): string {
+    const date = new Date(resumeAt)
+    return date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+}
 
 export function SettingsTestExecutionSection() {
     const {workers, setWorkers, resetToDefault} = usePlaywrightWorkers()
@@ -15,21 +28,34 @@ export function SettingsTestExecutionSection() {
         projectError,
         reloadProjects,
     } = usePlaywrightProject()
+    const {pause, isSaving: isSavingPause, pauseFor, resume} = useCIAutoRun()
+
+    const isPaused = pause?.paused ?? false
+    const resumeAt = pause?.resumeAt ?? null
 
     const handleWorkersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = parseInt(e.target.value, 10)
-        if (!isNaN(value)) {
-            setWorkers(value)
-        }
+        if (!isNaN(value)) setWorkers(value)
     }
 
     const handleProjectChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
         await setSelectedProject(e.target.value)
     }
 
+    const toggleClass = (active: boolean) =>
+        `relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 ${
+            active ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-white/10'
+        }`
+
+    const toggleKnobClass = (active: boolean) =>
+        `inline-block h-4 w-4 transform rounded-full bg-white shadow-soft transition-transform duration-200 ${
+            active ? 'translate-x-6' : 'translate-x-1'
+        }`
+
     return (
         <SettingsSection title="Test Execution" description="Configure test execution behavior">
             <div className="space-y-4">
+                {/* Maximum Workers */}
                 <div>
                     <label
                         htmlFor="max-workers"
@@ -60,75 +86,123 @@ export function SettingsTestExecutionSection() {
                     </p>
                 </div>
 
-                <div>
-                    <div className="flex items-center justify-between mb-2">
-                        <label
-                            htmlFor="playwright-project"
-                            className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            Playwright Project
-                        </label>
-                        <button
-                            onClick={reloadProjects}
+                {/* Divider: CI trigger script settings */}
+                <div className="rounded-2xl border border-gray-200/70 bg-gray-50/50 px-4 py-3 space-y-4 dark:border-white/[0.06] dark:bg-white/[0.02]">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                        CI Trigger Script
+                    </p>
+
+                    {/* Trigger script project */}
+                    <div>
+                        <div className="flex items-center justify-between mb-2">
+                            <label
+                                htmlFor="playwright-project"
+                                className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                Project
+                            </label>
+                            <button
+                                onClick={reloadProjects}
+                                disabled={isLoadingProjects || isSavingProject}
+                                className="text-xs font-medium text-gray-500 transition-colors hover:text-primary-600
+                                         dark:text-gray-400 dark:hover:text-primary-400 disabled:opacity-50">
+                                {isLoadingProjects ? 'Loading…' : 'Refresh'}
+                            </button>
+                        </div>
+                        <select
+                            id="playwright-project"
+                            value={selectedProject}
+                            onChange={(e) => {
+                                void handleProjectChange(e)
+                            }}
                             disabled={isLoadingProjects || isSavingProject}
-                            className="text-xs font-medium text-gray-500 transition-colors hover:text-primary-600
-                                     dark:text-gray-400 dark:hover:text-primary-400 disabled:opacity-50">
-                            {isLoadingProjects ? 'Loading…' : 'Refresh'}
+                            className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-gray-900 transition-all
+                                     focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500/60
+                                     dark:border-white/10 dark:bg-white/[0.05] dark:text-gray-100
+                                     disabled:opacity-50">
+                            <option value="">All Projects</option>
+                            {availableProjects.map((project) => (
+                                <option key={project} value={project}>
+                                    {project}
+                                </option>
+                            ))}
+                        </select>
+                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                            {selectedProject
+                                ? `trigger-test-run.sh will use "${selectedProject}"`
+                                : 'trigger-test-run.sh will run all projects'}
+                        </p>
+                        {projectError && (
+                            <p className="mt-2 text-sm text-danger-600 dark:text-danger-400">
+                                {projectError}
+                            </p>
+                        )}
+                    </div>
+
+                    {/* Auto-discover */}
+                    <div className="flex items-center justify-between gap-4">
+                        <div>
+                            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                Auto-discover before run
+                            </p>
+                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                                Discover new tests automatically before each run
+                            </p>
+                        </div>
+                        <button
+                            role="switch"
+                            aria-checked={autoDiscover}
+                            onClick={toggleAutoDiscover}
+                            className={toggleClass(autoDiscover)}>
+                            <span className={toggleKnobClass(autoDiscover)} />
                         </button>
                     </div>
-                    <select
-                        id="playwright-project"
-                        value={selectedProject}
-                        onChange={(e) => {
-                            void handleProjectChange(e)
-                        }}
-                        disabled={isLoadingProjects || isSavingProject}
-                        className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-gray-900 transition-all
-                                 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500/60
-                                 dark:border-white/10 dark:bg-white/[0.05] dark:text-gray-100
-                                 disabled:opacity-50">
-                        <option value="">All Projects</option>
-                        {availableProjects.map((project) => (
-                            <option key={project} value={project}>
-                                {project}
-                            </option>
-                        ))}
-                    </select>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                        {selectedProject
-                            ? `All test runs will use "${selectedProject}" for every user`
-                            : 'All projects defined in playwright.config.ts will run'}
-                    </p>
-                    {projectError && (
-                        <p className="mt-2 text-sm text-danger-600 dark:text-danger-400">
-                            {projectError}
-                        </p>
-                    )}
-                </div>
 
-                <div className="flex items-center justify-between gap-4 rounded-xl border border-gray-200/70 bg-white/60 px-4 py-3 dark:border-white/[0.06] dark:bg-white/[0.02]">
-                    <div>
-                        <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                            Auto-discover before run
-                        </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
-                            Discover new tests automatically before each run
-                        </p>
+                    {/* CI auto-run pause */}
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-4">
+                            <div>
+                                <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    Pause CI auto-run
+                                </p>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                    {isPaused && resumeAt
+                                        ? `Active · resumes at ${formatResumeTime(resumeAt)}`
+                                        : isPaused
+                                          ? 'Active · no auto-resume'
+                                          : 'Block trigger-test-run.sh from starting runs'}
+                                </p>
+                            </div>
+                            <button
+                                role="switch"
+                                aria-checked={isPaused}
+                                disabled={isSavingPause}
+                                onClick={() => (isPaused ? resume() : pauseFor(3))}
+                                className={toggleClass(isPaused) + ' disabled:opacity-50'}>
+                                <span className={toggleKnobClass(isPaused)} />
+                            </button>
+                        </div>
+
+                        {/* Duration picker — visible when about to pause or already paused */}
+                        {isPaused && (
+                            <div className="flex items-center gap-2">
+                                <span className="text-xs text-gray-500 dark:text-gray-400">
+                                    Change duration:
+                                </span>
+                                <div className="flex gap-1.5">
+                                    {DURATION_OPTIONS.map(({label, hours}) => (
+                                        <button
+                                            key={hours}
+                                            disabled={isSavingPause}
+                                            onClick={() => pauseFor(hours)}
+                                            className="rounded-lg border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:border-primary-400 hover:text-primary-600 disabled:opacity-50
+                                                     dark:border-white/10 dark:bg-white/[0.04] dark:text-gray-400 dark:hover:border-primary-400 dark:hover:text-primary-400">
+                                            {label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
-                    <button
-                        role="switch"
-                        aria-checked={autoDiscover}
-                        onClick={toggleAutoDiscover}
-                        className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 ${
-                            autoDiscover
-                                ? 'bg-primary-600 dark:bg-primary-500'
-                                : 'bg-gray-200 dark:bg-white/10'
-                        }`}>
-                        <span
-                            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-soft transition-transform duration-200 ${
-                                autoDiscover ? 'translate-x-6' : 'translate-x-1'
-                            }`}
-                        />
-                    </button>
                 </div>
             </div>
         </SettingsSection>

--- a/packages/web/src/features/tests/components/TestsList.tsx
+++ b/packages/web/src/features/tests/components/TestsList.tsx
@@ -16,6 +16,7 @@ export interface TestsListProps {
     onTestRerun: (testId: string) => void
     selectedTest: TestResult | null
     loading: boolean
+    activeProject?: string
 }
 
 export default function TestsList({
@@ -23,6 +24,7 @@ export default function TestsList({
     onTestRerun,
     selectedTest,
     loading,
+    activeProject,
 }: TestsListProps) {
     const {tests, error} = useTestsStore()
     const [searchParams, setSearchParams] = useSearchParams()
@@ -50,6 +52,7 @@ export default function TestsList({
         tests,
         filter,
         searchQuery,
+        projectFilter: activeProject || undefined,
     })
 
     // Sync filter with URL parameter changes
@@ -204,6 +207,7 @@ export default function TestsList({
                     onSearchChange={handleSearchChange}
                     filteredCount={filteredTests.length}
                     searchInputRef={searchInputRef}
+                    activeProject={activeProject}
                 />
             </div>
 

--- a/packages/web/src/features/tests/components/TestsListFilters.tsx
+++ b/packages/web/src/features/tests/components/TestsListFilters.tsx
@@ -21,6 +21,7 @@ export interface TestsListFiltersProps {
     onExpandAll?: () => void
     onCollapseAll?: () => void
     searchInputRef?: RefObject<HTMLInputElement>
+    activeProject?: string
 }
 
 export function TestsListFilters({
@@ -31,6 +32,7 @@ export function TestsListFilters({
     onSearchChange,
     filteredCount,
     searchInputRef,
+    activeProject,
 }: TestsListFiltersProps) {
     const {runAllTests, isRunningAllTests, getIsAnyTestRunning} = useTestsStore()
     const isAnyTestRunning = getIsAnyTestRunning()
@@ -48,7 +50,7 @@ export function TestsListFilters({
                     variant="primary"
                     loading={isRunningAllTests}
                     disabled={isAnyTestRunning}
-                    onClick={runAllTests}
+                    onClick={() => runAllTests(activeProject || undefined)}
                     className="shrink-0">
                     {isRunningAllTests ? (
                         'Running...'

--- a/packages/web/src/features/tests/hooks/__tests__/useTestFilters.test.ts
+++ b/packages/web/src/features/tests/hooks/__tests__/useTestFilters.test.ts
@@ -232,6 +232,119 @@ describe('useTestFilters', () => {
         })
     })
 
+    describe('projectFilter', () => {
+        const createMockTestWithProject = (
+            id: string,
+            status: 'passed' | 'failed' | 'skipped' | 'pending',
+            name: string,
+            project: string | undefined
+        ): TestResult => ({
+            id,
+            testId: `test-${id}`,
+            name,
+            filePath: `/path/to/${name}.spec.ts`,
+            status,
+            duration: 100,
+            timestamp: new Date().toISOString(),
+            runId: 'run-1',
+            project,
+        })
+
+        const mixedProjectTests: TestResult[] = [
+            createMockTestWithProject('1', 'passed', 'FE Test 1', 'Frontend'),
+            createMockTestWithProject('2', 'failed', 'FE Test 2', 'Frontend'),
+            createMockTestWithProject('3', 'passed', 'BE Test 1', 'Backend'),
+            createMockTestWithProject('4', 'skipped', 'BE Test 2', 'Backend'),
+            createMockTestWithProject('5', 'pending', 'No Project Test', undefined),
+        ]
+
+        it('should show only tests matching projectFilter', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'all',
+                    searchQuery: '',
+                    projectFilter: 'Frontend',
+                })
+            )
+
+            expect(result.current.filteredTests).toHaveLength(2)
+            expect(result.current.filteredTests.every((t) => t.project === 'Frontend')).toBe(true)
+        })
+
+        it('should apply intersection of projectFilter and status filter', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'failed',
+                    searchQuery: '',
+                    projectFilter: 'Frontend',
+                })
+            )
+
+            expect(result.current.filteredTests).toHaveLength(1)
+            expect(result.current.filteredTests[0].id).toBe('2')
+            expect(result.current.filteredTests[0].status).toBe('failed')
+            expect(result.current.filteredTests[0].project).toBe('Frontend')
+        })
+
+        it('should apply intersection of projectFilter and searchQuery', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'all',
+                    searchQuery: 'FE Test 1',
+                    projectFilter: 'Frontend',
+                })
+            )
+
+            expect(result.current.filteredTests).toHaveLength(1)
+            expect(result.current.filteredTests[0].name).toBe('FE Test 1')
+        })
+
+        it('should treat test with undefined project as empty string — does not appear for projectFilter=Frontend', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'all',
+                    searchQuery: '',
+                    projectFilter: 'Frontend',
+                })
+            )
+
+            const ids = result.current.filteredTests.map((t) => t.id)
+            expect(ids).not.toContain('5')
+        })
+
+        it('counts.all reflects only project-scoped tests when projectFilter is set', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'all',
+                    searchQuery: '',
+                    projectFilter: 'Frontend',
+                })
+            )
+
+            expect(result.current.counts.all).toBe(2)
+            expect(result.current.counts.passed).toBe(1)
+            expect(result.current.counts.failed).toBe(1)
+        })
+
+        it('should show all tests when projectFilter is not set (no regression)', () => {
+            const {result} = renderHook(() =>
+                useTestFilters({
+                    tests: mixedProjectTests,
+                    filter: 'all',
+                    searchQuery: '',
+                })
+            )
+
+            expect(result.current.filteredTests).toHaveLength(5)
+            expect(result.current.counts.all).toBe(5)
+        })
+    })
+
     describe('Edge cases', () => {
         it('should handle empty test array', () => {
             const {result} = renderHook(() =>

--- a/packages/web/src/features/tests/hooks/useTestFilters.ts
+++ b/packages/web/src/features/tests/hooks/useTestFilters.ts
@@ -6,6 +6,7 @@ export interface UseTestFiltersProps {
     tests: TestResult[]
     filter: FilterKey
     searchQuery: string
+    projectFilter?: string
 }
 
 export interface UseTestFiltersReturn {
@@ -24,9 +25,14 @@ export function useTestFilters({
     tests,
     filter,
     searchQuery,
+    projectFilter,
 }: UseTestFiltersProps): UseTestFiltersReturn {
     const filteredTests = useMemo(() => {
         return tests.filter((test) => {
+            // Project filter: strict match — only tests belonging to this project
+            if (projectFilter) {
+                if ((test.project || '') !== projectFilter) return false
+            }
             // Handle 'noted' filter - show only tests with notes
             if (filter === 'noted') {
                 const hasNote = test.note && test.note.content && test.note.content.trim() !== ''
@@ -55,19 +61,25 @@ export function useTestFilters({
 
             return statusMatch && searchMatch
         })
-    }, [tests, filter, searchQuery])
+    }, [tests, filter, searchQuery, projectFilter])
+
+    const projectTests = useMemo(
+        () => (projectFilter ? tests.filter((t) => (t.project || '') === projectFilter) : tests),
+        [tests, projectFilter]
+    )
 
     const counts = useMemo(
         () => ({
-            all: tests.length,
-            passed: tests.filter((t) => t.status === 'passed').length,
-            failed: tests.filter((t) => t.status === 'failed').length,
-            skipped: tests.filter((t) => t.status === 'skipped').length,
-            pending: tests.filter((t) => t.status === 'pending').length,
-            noted: tests.filter((t) => t.note && t.note.content && t.note.content.trim() !== '')
-                .length,
+            all: projectTests.length,
+            passed: projectTests.filter((t) => t.status === 'passed').length,
+            failed: projectTests.filter((t) => t.status === 'failed').length,
+            skipped: projectTests.filter((t) => t.status === 'skipped').length,
+            pending: projectTests.filter((t) => t.status === 'pending').length,
+            noted: projectTests.filter(
+                (t) => t.note && t.note.content && t.note.content.trim() !== ''
+            ).length,
         }),
-        [tests]
+        [projectTests]
     )
 
     return {filteredTests, counts}

--- a/packages/web/src/features/tests/store/testsStore.ts
+++ b/packages/web/src/features/tests/store/testsStore.ts
@@ -29,7 +29,7 @@ interface TestsState {
     deleteTest: (testId: string) => Promise<void>
     deleteExecution: (testId: string, executionId: string) => Promise<void>
     discoverTests: () => Promise<void>
-    runAllTests: () => Promise<void>
+    runAllTests: (project?: string) => Promise<void>
     runTestsGroup: (filePath: string, testNames?: string[]) => Promise<void>
     clearError: () => void
     setTestRunning: (testId: string, isRunning: boolean) => void
@@ -263,7 +263,7 @@ export const useTestsStore = create<TestsState>()(
                 }
             },
 
-            runAllTests: async () => {
+            runAllTests: async (project?: string) => {
                 try {
                     const autoDiscover = getAutoDiscoverFromStorage()
 
@@ -302,6 +302,7 @@ export const useTestsStore = create<TestsState>()(
                     const maxWorkers = getMaxWorkersFromStorage()
                     const response = await authPost(`${API_BASE_URL}/tests/run-all`, {
                         maxWorkers,
+                        project: project || undefined,
                         skipAutoDiscovery: true, // discovery already handled above (or disabled)
                     })
 

--- a/packages/web/src/hooks/__tests__/useProjectTabs.test.ts
+++ b/packages/web/src/hooks/__tests__/useProjectTabs.test.ts
@@ -1,0 +1,144 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
+import {renderHook, waitFor} from '@testing-library/react'
+import {useProjectTabs} from '../useProjectTabs'
+
+// Mock authFetch so we can control responses without a real server
+vi.mock('@features/authentication/utils/authFetch', () => ({
+    authGet: vi.fn(),
+    authPut: vi.fn(),
+}))
+
+// Mock config to avoid VITE env lookup
+vi.mock('@config/environment.config', () => ({
+    config: {
+        api: {
+            baseUrl: 'http://localhost:3000/api',
+        },
+    },
+}))
+
+import {authGet} from '@features/authentication/utils/authFetch'
+
+const mockAuthGet = authGet as ReturnType<typeof vi.fn>
+
+function makeResponse(body: unknown, ok = true): Response {
+    return {
+        ok,
+        json: () => Promise.resolve(body),
+    } as unknown as Response
+}
+
+describe('useProjectTabs', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('merge logic', () => {
+        it('should append new available project not in saved configs with visible=true and displayName=projectName', async () => {
+            const savedConfigs = [{project: 'Frontend', displayName: 'FE Tests', visible: true}]
+            const availableProjects = ['Frontend', 'Backend']
+
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({data: savedConfigs}))
+                .mockResolvedValueOnce(makeResponse({data: availableProjects}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.tabs).toHaveLength(2)
+            const backendTab = result.current.tabs.find((t) => t.project === 'Backend')
+            expect(backendTab).toBeDefined()
+            expect(backendTab?.visible).toBe(true)
+            expect(backendTab?.displayName).toBe('Backend')
+        })
+
+        it('should not produce duplicates when available projects match saved configs', async () => {
+            const savedConfigs = [
+                {project: 'Frontend', displayName: 'FE', visible: true},
+                {project: 'Backend', displayName: 'BE', visible: false},
+            ]
+            const availableProjects = ['Frontend', 'Backend']
+
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({data: savedConfigs}))
+                .mockResolvedValueOnce(makeResponse({data: availableProjects}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.tabs).toHaveLength(2)
+        })
+
+        it('should retain saved entry even if project is no longer in available list', async () => {
+            const savedConfigs = [
+                {project: 'Frontend', displayName: 'FE', visible: true},
+                {project: 'Legacy', displayName: 'Old Suite', visible: false},
+            ]
+            const availableProjects = ['Frontend']
+
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({data: savedConfigs}))
+                .mockResolvedValueOnce(makeResponse({data: availableProjects}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.tabs).toHaveLength(2)
+            const legacyTab = result.current.tabs.find((t) => t.project === 'Legacy')
+            expect(legacyTab).toBeDefined()
+        })
+
+        it('should result in empty tabs when both fetches return empty', async () => {
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({data: []}))
+                .mockResolvedValueOnce(makeResponse({data: []}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.tabs).toEqual([])
+            expect(result.current.error).toBeNull()
+        })
+
+        it('should set error and leave tabs empty when settings fetch fails', async () => {
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({}, false))
+                .mockResolvedValueOnce(makeResponse({data: ['Frontend']}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.error).toBeTruthy()
+            expect(result.current.tabs).toEqual([])
+        })
+
+        it('visibleTabs should contain only tabs where visible is true', async () => {
+            const savedConfigs = [
+                {project: 'Frontend', displayName: 'FE', visible: true},
+                {project: 'Backend', displayName: 'BE', visible: false},
+                {project: 'Mobile', displayName: 'Mobile', visible: true},
+            ]
+
+            mockAuthGet
+                .mockResolvedValueOnce(makeResponse({data: savedConfigs}))
+                .mockResolvedValueOnce(makeResponse({data: ['Frontend', 'Backend', 'Mobile']}))
+
+            const {result} = renderHook(() => useProjectTabs())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+            expect(result.current.visibleTabs).toHaveLength(2)
+            expect(result.current.visibleTabs.every((t) => t.visible)).toBe(true)
+            expect(result.current.visibleTabs.map((t) => t.project)).toEqual(['Frontend', 'Mobile'])
+        })
+    })
+})

--- a/packages/web/src/hooks/useCIAutoRun.ts
+++ b/packages/web/src/hooks/useCIAutoRun.ts
@@ -1,0 +1,77 @@
+import {useState, useEffect, useCallback} from 'react'
+import {authGet, authPut} from '@features/authentication/utils/authFetch'
+import {config} from '@config/environment.config'
+
+export interface CIAutoRunPause {
+    paused: boolean
+    resumeAt: string | null
+}
+
+export interface UseCIAutoRunReturn {
+    pause: CIAutoRunPause | null
+    isLoading: boolean
+    isSaving: boolean
+    pauseFor: (durationHours: number) => Promise<void>
+    resume: () => Promise<void>
+    reload: () => Promise<void>
+}
+
+export function useCIAutoRun(): UseCIAutoRunReturn {
+    const [pause, setPause] = useState<CIAutoRunPause | null>(null)
+    const [isLoading, setIsLoading] = useState(false)
+    const [isSaving, setIsSaving] = useState(false)
+
+    const reload = useCallback(async () => {
+        setIsLoading(true)
+        try {
+            const res = await authGet(`${config.api.baseUrl}/settings/ci-autorun-pause`)
+            if (!res.ok) throw new Error('Failed to load CI auto-run pause state')
+            const data = await res.json()
+            const raw: CIAutoRunPause = data.data ?? data
+            // Auto-resume client-side if time passed
+            if (raw.paused && raw.resumeAt && new Date(raw.resumeAt) <= new Date()) {
+                setPause({paused: false, resumeAt: null})
+            } else {
+                setPause(raw)
+            }
+        } catch {
+            // silently fail — feature degrades gracefully
+        } finally {
+            setIsLoading(false)
+        }
+    }, [])
+
+    const pauseFor = useCallback(async (durationHours: number) => {
+        setIsSaving(true)
+        try {
+            const res = await authPut(`${config.api.baseUrl}/settings/ci-autorun-pause`, {
+                paused: true,
+                durationHours,
+            })
+            if (!res.ok) throw new Error('Failed to pause CI auto-run')
+            const data = await res.json()
+            setPause(data.data ?? data)
+        } finally {
+            setIsSaving(false)
+        }
+    }, [])
+
+    const resume = useCallback(async () => {
+        setIsSaving(true)
+        try {
+            const res = await authPut(`${config.api.baseUrl}/settings/ci-autorun-pause`, {
+                paused: false,
+            })
+            if (!res.ok) throw new Error('Failed to resume CI auto-run')
+            setPause({paused: false, resumeAt: null})
+        } finally {
+            setIsSaving(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        reload()
+    }, [reload])
+
+    return {pause, isLoading, isSaving, pauseFor, resume, reload}
+}

--- a/packages/web/src/hooks/useProjectTabs.ts
+++ b/packages/web/src/hooks/useProjectTabs.ts
@@ -1,0 +1,94 @@
+import {useState, useEffect, useCallback} from 'react'
+import {authGet, authPut} from '@features/authentication/utils/authFetch'
+import {config} from '@config/environment.config'
+
+export interface ProjectTabConfig {
+    project: string
+    displayName: string
+    visible: boolean
+}
+
+export interface UseProjectTabsReturn {
+    tabs: ProjectTabConfig[]
+    visibleTabs: ProjectTabConfig[]
+    updateTabs: (configs: ProjectTabConfig[]) => Promise<void>
+    isLoading: boolean
+    isSaving: boolean
+    error: string | null
+    reload: () => Promise<void>
+}
+
+export function useProjectTabs(): UseProjectTabsReturn {
+    const [tabs, setTabs] = useState<ProjectTabConfig[]>([])
+    const [isLoading, setIsLoading] = useState(false)
+    const [isSaving, setIsSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const reload = useCallback(async () => {
+        setIsLoading(true)
+        setError(null)
+
+        try {
+            const [tabsRes, projectsRes] = await Promise.all([
+                authGet(`${config.api.baseUrl}/settings/project-tabs`),
+                authGet(`${config.api.baseUrl}/tests/projects`),
+            ])
+
+            if (!tabsRes.ok || !projectsRes.ok) {
+                throw new Error('Failed to load project tab settings')
+            }
+
+            const tabsData = await tabsRes.json()
+            const projectsData = await projectsRes.json()
+
+            const saved: ProjectTabConfig[] = tabsData.data ?? []
+            const available: string[] = projectsData.data ?? projectsData ?? []
+
+            // Merge: start from saved configs, add any new projects not yet configured
+            const savedProjects = new Set(saved.map((c) => c.project))
+            const merged: ProjectTabConfig[] = [...saved]
+
+            for (const project of available) {
+                if (!savedProjects.has(project)) {
+                    merged.push({project, displayName: project, visible: true})
+                }
+            }
+
+            setTabs(merged)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to load project tabs')
+        } finally {
+            setIsLoading(false)
+        }
+    }, [])
+
+    const updateTabs = useCallback(async (configs: ProjectTabConfig[]) => {
+        setIsSaving(true)
+        setError(null)
+
+        try {
+            const res = await authPut(`${config.api.baseUrl}/settings/project-tabs`, {configs})
+
+            if (!res.ok) {
+                const data = await res.json().catch(() => null)
+                throw new Error(data?.message || 'Failed to save project tab configs')
+            }
+
+            const data = await res.json()
+            setTabs(data.data ?? configs)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to save project tabs')
+            throw err
+        } finally {
+            setIsSaving(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        reload()
+    }, [reload])
+
+    const visibleTabs = tabs.filter((t) => t.visible)
+
+    return {tabs, visibleTabs, updateTabs, isLoading, isSaving, error, reload}
+}

--- a/packages/web/src/shared/components/Header.tsx
+++ b/packages/web/src/shared/components/Header.tsx
@@ -1,29 +1,22 @@
 import {useState, useEffect} from 'react'
 import {useNavigate, useLocation} from 'react-router-dom'
-import {
-    Settings,
-    LogOut,
-    LayoutDashboard,
-    FlaskConical,
-    ChevronDown,
-    Menu,
-    X,
-    Moon,
-    Sun,
-} from 'lucide-react'
+import {Settings, LogOut, LayoutDashboard, ChevronDown, Menu, X, Moon, Sun} from 'lucide-react'
 import {useTheme} from '@/hooks/useTheme'
+import {ProjectTabConfig} from '@/hooks/useProjectTabs'
 
 interface HeaderProps {
-    currentView: 'dashboard' | 'tests'
-    onViewChange: (view: 'dashboard' | 'tests') => void
+    activeProject: string
+    projectTabs: ProjectTabConfig[]
+    tabsLoading?: boolean
     wsConnected?: boolean
     user?: (() => {email: string; role?: string}) | {email: string; role?: string}
     onOpenSettings?: () => void
 }
 
 export default function Header({
-    currentView,
-    onViewChange,
+    activeProject,
+    projectTabs,
+    tabsLoading = false,
     wsConnected = false,
     user,
     onOpenSettings,
@@ -71,7 +64,6 @@ export default function Header({
         window.location.reload()
     }
 
-    // Get user data (handle both function and object types)
     const getUserData = () => {
         if (typeof user === 'function') {
             return user()
@@ -79,32 +71,42 @@ export default function Header({
         return user || null
     }
 
-    // Handle view changes with URL preservation
-    const handleViewChange = (view: 'dashboard' | 'tests') => {
-        if (view === 'tests') {
-            const params = new URLSearchParams(location.search)
-            const filter = params.get('filter')
-            navigate(filter ? `/tests?filter=${filter}` : '/tests')
-        } else {
-            navigate('/dashboard')
-        }
-        onViewChange(view)
+    const handleProjectTabClick = (project: string) => {
+        const params = new URLSearchParams(location.search)
+        params.set('project', project)
+        // Preserve filter param if present
+        const filter = params.get('filter')
+        const newParams = new URLSearchParams()
+        newParams.set('project', project)
+        if (filter) newParams.set('filter', filter)
+        navigate(`/tests?${newParams.toString()}`)
         setMobileMenuOpen(false)
     }
 
-    const navItemClass = (active: boolean) =>
+    const handleDashboardClick = () => {
+        navigate('/dashboard')
+        setMobileMenuOpen(false)
+    }
+
+    const isDashboard = location.pathname.includes('/dashboard')
+
+    const tabClass = (active: boolean) =>
         `relative px-4 py-2 text-sm font-medium rounded-xl transition-all duration-200 ${
             active
                 ? 'bg-primary-50 text-primary-700 shadow-soft dark:bg-primary-500/15 dark:text-primary-300'
                 : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100/80 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/[0.06]'
         }`
 
+    const dashboardIconClass = isDashboard
+        ? 'flex items-center justify-center w-9 h-9 rounded-xl bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300 transition-all duration-200'
+        : 'flex items-center justify-center w-9 h-9 rounded-xl text-gray-500 hover:text-gray-900 hover:bg-gray-100/80 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/[0.06] transition-all duration-200'
+
     return (
         <>
             <header className="sticky top-0 z-50 border-b border-gray-200/70 bg-white/80 backdrop-blur-xl dark:border-white/[0.06] dark:bg-gray-950/70">
                 <div className="container mx-auto px-4">
                     <div className="flex items-center justify-between h-14 md:h-16">
-                        {/* Logo and title */}
+                        {/* Logo */}
                         <div className="flex items-center space-x-2 md:space-x-4 min-w-0">
                             <div className="flex items-center space-x-3 min-w-0">
                                 <a
@@ -144,18 +146,42 @@ export default function Header({
                         </div>
 
                         {/* Desktop Navigation */}
-                        <nav className="hidden md:flex items-center gap-1 rounded-2xl bg-gray-100/60 p-1 dark:bg-white/[0.04]">
+                        <div className="hidden md:flex items-center gap-2">
+                            {/* Dashboard icon button */}
                             <button
-                                onClick={() => handleViewChange('dashboard')}
-                                className={navItemClass(currentView === 'dashboard')}>
-                                Dashboard
+                                onClick={handleDashboardClick}
+                                title="Dashboard"
+                                className={dashboardIconClass}>
+                                <LayoutDashboard className="w-4 h-4" />
                             </button>
-                            <button
-                                onClick={() => handleViewChange('tests')}
-                                className={navItemClass(currentView === 'tests')}>
-                                Tests
-                            </button>
-                        </nav>
+
+                            {/* Project tabs */}
+                            <nav className="flex items-center gap-1 rounded-2xl bg-gray-100/60 p-1 dark:bg-white/[0.04]">
+                                {tabsLoading ? (
+                                    <>
+                                        <div className="h-8 w-20 animate-pulse rounded-xl bg-gray-200/80 dark:bg-white/[0.08]" />
+                                        <div className="h-8 w-20 animate-pulse rounded-xl bg-gray-200/80 dark:bg-white/[0.08]" />
+                                    </>
+                                ) : projectTabs.length > 0 ? (
+                                    projectTabs.map((tab) => (
+                                        <button
+                                            key={tab.project}
+                                            onClick={() => handleProjectTabClick(tab.project)}
+                                            className={tabClass(
+                                                !isDashboard && activeProject === tab.project
+                                            )}>
+                                            {tab.displayName}
+                                        </button>
+                                    ))
+                                ) : (
+                                    <button
+                                        onClick={() => navigate('/tests')}
+                                        className={tabClass(!isDashboard)}>
+                                        Tests
+                                    </button>
+                                )}
+                            </nav>
+                        </div>
 
                         {/* Desktop: status + user menu */}
                         <div className="hidden md:flex items-center gap-3">
@@ -280,23 +306,47 @@ export default function Header({
                                 Navigation
                             </p>
                             <button
-                                onClick={() => handleViewChange('dashboard')}
+                                onClick={handleDashboardClick}
                                 className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
-                                    currentView === 'dashboard'
+                                    isDashboard
                                         ? 'bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300'
                                         : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/[0.06]'
                                 }`}>
                                 <LayoutDashboard className="h-4 w-4 flex-shrink-0" /> Dashboard
                             </button>
-                            <button
-                                onClick={() => handleViewChange('tests')}
-                                className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
-                                    currentView === 'tests'
-                                        ? 'bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300'
-                                        : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/[0.06]'
-                                }`}>
-                                <FlaskConical className="h-4 w-4 flex-shrink-0" /> Tests
-                            </button>
+
+                            {tabsLoading ? (
+                                <>
+                                    <div className="h-10 animate-pulse rounded-xl bg-gray-100 dark:bg-white/[0.06]" />
+                                    <div className="h-10 animate-pulse rounded-xl bg-gray-100 dark:bg-white/[0.06]" />
+                                </>
+                            ) : projectTabs.length > 0 ? (
+                                projectTabs.map((tab) => (
+                                    <button
+                                        key={tab.project}
+                                        onClick={() => handleProjectTabClick(tab.project)}
+                                        className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
+                                            !isDashboard && activeProject === tab.project
+                                                ? 'bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300'
+                                                : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/[0.06]'
+                                        }`}>
+                                        {tab.displayName}
+                                    </button>
+                                ))
+                            ) : (
+                                <button
+                                    onClick={() => {
+                                        navigate('/tests')
+                                        setMobileMenuOpen(false)
+                                    }}
+                                    className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
+                                        !isDashboard
+                                            ? 'bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300'
+                                            : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/[0.06]'
+                                    }`}>
+                                    Tests
+                                </button>
+                            )}
 
                             <div className="my-3 border-t border-gray-200/70 dark:border-white/[0.06]" />
 

--- a/packages/web/src/shared/components/__tests__/Header.test.tsx
+++ b/packages/web/src/shared/components/__tests__/Header.test.tsx
@@ -3,6 +3,7 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {MemoryRouter} from 'react-router-dom'
 import Header from '../Header'
+import {ProjectTabConfig} from '@/hooks/useProjectTabs'
 
 // Mock useTheme hook
 vi.mock('@/hooks/useTheme', () => ({
@@ -19,13 +20,16 @@ vi.mock('react-router-dom', async () => {
     }
 })
 
-describe('Header - Filter Preservation', () => {
-    const mockOnViewChange = vi.fn()
+const sampleTabs: ProjectTabConfig[] = [
+    {project: 'All_Tests', displayName: 'All Tests', visible: true},
+    {project: 'Frontend', displayName: 'Frontend', visible: true},
+]
+
+describe('Header', () => {
     const mockOnOpenSettings = vi.fn()
 
     beforeEach(() => {
         mockNavigate.mockClear()
-        mockOnViewChange.mockClear()
         mockOnOpenSettings.mockClear()
     })
 
@@ -33,216 +37,122 @@ describe('Header - Filter Preservation', () => {
         return render(<MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>)
     }
 
-    describe('Navigation - Dashboard', () => {
+    describe('Navigation - Dashboard icon', () => {
         it('should navigate to /dashboard when Dashboard button is clicked', async () => {
             const user = userEvent.setup()
 
             renderWithRouter(
-                <Header currentView="tests" onViewChange={mockOnViewChange} wsConnected={true} />
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />
             )
 
-            const dashboardButton = screen.getByText('Dashboard')
+            const dashboardButton = screen.getByTitle('Dashboard')
             await user.click(dashboardButton)
 
             expect(mockNavigate).toHaveBeenCalledWith('/dashboard')
-            expect(mockOnViewChange).toHaveBeenCalledWith('dashboard')
         })
+    })
 
-        it('should not preserve filter when navigating to dashboard', async () => {
+    describe('Navigation - Project tabs', () => {
+        it('should navigate to /tests?project=<name> when a project tab is clicked', async () => {
             const user = userEvent.setup()
 
             renderWithRouter(
-                <Header currentView="tests" onViewChange={mockOnViewChange} wsConnected={true} />,
-                ['/?filter=failed']
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />
             )
 
-            const dashboardButton = screen.getByText('Dashboard')
-            await user.click(dashboardButton)
+            const allTestsTab = screen.getAllByText('All Tests')[0]
+            await user.click(allTestsTab)
 
-            expect(mockNavigate).toHaveBeenCalledWith('/dashboard')
+            expect(mockNavigate).toHaveBeenCalledWith('/tests?project=All_Tests')
+        })
+
+        it('should preserve filter parameter when clicking a project tab', async () => {
+            const user = userEvent.setup()
+
+            renderWithRouter(
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests?filter=failed']
+            )
+
+            const frontendTab = screen.getAllByText('Frontend')[0]
+            await user.click(frontendTab)
+
+            expect(mockNavigate).toHaveBeenCalledWith('/tests?project=Frontend&filter=failed')
+        })
+
+        it('should not include filter param if none is present', async () => {
+            const user = userEvent.setup()
+
+            renderWithRouter(
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests']
+            )
+
+            const allTestsTab = screen.getAllByText('All Tests')[0]
+            await user.click(allTestsTab)
+
+            expect(mockNavigate).toHaveBeenCalledWith('/tests?project=All_Tests')
             expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('filter'))
         })
     })
 
-    describe('Navigation - Tests', () => {
-        it('should navigate to /tests when Tests button is clicked', async () => {
+    describe('Navigation - Fallback Tests button', () => {
+        it('should show "Tests" button when projectTabs is empty', () => {
+            renderWithRouter(<Header activeProject="" projectTabs={[]} wsConnected={true} />)
+
+            expect(screen.getByText('Tests')).toBeInTheDocument()
+        })
+
+        it('should navigate to /tests when fallback Tests button is clicked', async () => {
             const user = userEvent.setup()
 
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />
-            )
+            renderWithRouter(<Header activeProject="" projectTabs={[]} wsConnected={true} />)
 
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
+            await user.click(screen.getByText('Tests'))
 
             expect(mockNavigate).toHaveBeenCalledWith('/tests')
-            expect(mockOnViewChange).toHaveBeenCalledWith('tests')
-        })
-
-        it('should preserve filter parameter when navigating to tests', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=failed']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=failed')
-            expect(mockOnViewChange).toHaveBeenCalledWith('tests')
-        })
-
-        it('should preserve "passed" filter when navigating to tests', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=passed']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=passed')
-        })
-
-        it('should preserve "skipped" filter when navigating to tests', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=skipped']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=skipped')
-        })
-
-        it('should preserve "pending" filter when navigating to tests', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=pending']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=pending')
-        })
-
-        it('should navigate to /tests without filter when no filter is present', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests')
-            expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('filter'))
         })
     })
 
     describe('Visual States', () => {
-        it('should highlight Dashboard button when on dashboard view', () => {
+        it('should highlight active project tab', () => {
             renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />
+                <Header activeProject="All_Tests" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests?project=All_Tests']
             )
 
-            const dashboardButton = screen.getByText('Dashboard')
-            expect(dashboardButton).toHaveClass('bg-primary-50')
+            const activeTab = screen.getAllByText('All Tests')[0]
+            expect(activeTab).toHaveClass('bg-primary-50')
         })
 
-        it('should highlight Tests button when on tests view', () => {
+        it('should not highlight inactive project tab', () => {
             renderWithRouter(
-                <Header currentView="tests" onViewChange={mockOnViewChange} wsConnected={true} />
+                <Header activeProject="All_Tests" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests?project=All_Tests']
             )
 
-            const testsButton = screen.getByText('Tests')
-            expect(testsButton).toHaveClass('bg-primary-50')
+            const inactiveTab = screen.getAllByText('Frontend')[0]
+            expect(inactiveTab).not.toHaveClass('bg-primary-50')
         })
 
-        it('should not highlight Dashboard button when on tests view', () => {
-            renderWithRouter(
-                <Header currentView="tests" onViewChange={mockOnViewChange} wsConnected={true} />
-            )
+        it('should highlight Tests fallback button when on tests page with no tabs', () => {
+            renderWithRouter(<Header activeProject="" projectTabs={[]} wsConnected={true} />, [
+                '/tests',
+            ])
 
-            const dashboardButton = screen.getByText('Dashboard')
-            expect(dashboardButton).not.toHaveClass('bg-primary-50')
-        })
-
-        it('should not highlight Tests button when on dashboard view', () => {
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />
-            )
-
-            const testsButton = screen.getByText('Tests')
-            expect(testsButton).not.toHaveClass('bg-primary-50')
+            expect(screen.getByText('Tests')).toHaveClass('bg-primary-50')
         })
     })
 
     describe('WebSocket Connection Status', () => {
         it('should show connected status when wsConnected is true', () => {
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />
-            )
+            renderWithRouter(<Header activeProject="" projectTabs={[]} wsConnected={true} />)
 
             expect(screen.getByText('Live')).toBeInTheDocument()
         })
 
         it('should show disconnected status when wsConnected is false', () => {
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={false}
-                />
-            )
+            renderWithRouter(<Header activeProject="" projectTabs={[]} wsConnected={false} />)
 
             expect(screen.getByText('Offline')).toBeInTheDocument()
         })
@@ -250,15 +160,10 @@ describe('Header - Filter Preservation', () => {
 
     describe('User Menu', () => {
         it('should display user email when user is provided', () => {
-            const user = {email: 'test@example.com', role: 'admin'}
+            const testUser = {email: 'test@example.com', role: 'admin'}
 
             renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                    user={user}
-                />
+                <Header activeProject="" projectTabs={[]} wsConnected={true} user={testUser} />
             )
 
             expect(screen.getByText('test@example.com')).toBeInTheDocument()
@@ -270,132 +175,61 @@ describe('Header - Filter Preservation', () => {
 
             renderWithRouter(
                 <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
+                    activeProject=""
+                    projectTabs={[]}
                     wsConnected={true}
                     user={testUser}
                     onOpenSettings={mockOnOpenSettings}
                 />
             )
 
-            // Click on user menu button
-            const userButton = screen.getByText('test@example.com')
-            await user.click(userButton)
-
-            // Click on Settings option
-            const settingsButton = screen.getByText('Settings')
-            await user.click(settingsButton)
+            await user.click(screen.getByText('test@example.com'))
+            await user.click(screen.getByText('Settings'))
 
             expect(mockOnOpenSettings).toHaveBeenCalledTimes(1)
         })
     })
 
-    describe('Multiple Navigation Actions', () => {
-        it('should handle multiple navigation clicks', async () => {
+    describe('Multiple navigation clicks', () => {
+        it('should handle clicking the same tab twice', async () => {
             const user = userEvent.setup()
 
             renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=failed']
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests?filter=failed']
             )
 
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-            await user.click(testsButton)
+            const tab = screen.getAllByText('All Tests')[0]
+            await user.click(tab)
+            await user.click(tab)
 
             expect(mockNavigate).toHaveBeenCalledTimes(2)
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=failed')
-        })
-
-        it('should handle switching between views', async () => {
-            const user = userEvent.setup()
-
-            const {rerender} = renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=failed']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=failed')
-
-            // Switch to tests view and then back to dashboard
-            rerender(
-                <MemoryRouter initialEntries={['/?filter=failed']}>
-                    <Header
-                        currentView="tests"
-                        onViewChange={mockOnViewChange}
-                        wsConnected={true}
-                    />
-                </MemoryRouter>
-            )
-
-            const dashboardButton = screen.getByText('Dashboard')
-            await user.click(dashboardButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/dashboard')
+            expect(mockNavigate).toHaveBeenCalledWith('/tests?project=All_Tests&filter=failed')
         })
     })
 
     describe('Edge Cases', () => {
-        it('should handle navigation with multiple query parameters', async () => {
+        it('should ignore non-filter query params when building project tab URL', async () => {
             const user = userEvent.setup()
 
             renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=failed&testId=test-123']
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />,
+                ['/tests?filter=failed&testId=test-123']
             )
 
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
+            const tab = screen.getAllByText('Frontend')[0]
+            await user.click(tab)
 
-            // Should preserve filter but navigation will handle testId separately
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=failed')
+            expect(mockNavigate).toHaveBeenCalledWith('/tests?project=Frontend&filter=failed')
         })
 
-        it('should handle navigation from tests back to tests', async () => {
-            const user = userEvent.setup()
-
+        it('should render all provided project tab labels', () => {
             renderWithRouter(
-                <Header currentView="tests" onViewChange={mockOnViewChange} wsConnected={true} />,
-                ['/?filter=passed']
+                <Header activeProject="" projectTabs={sampleTabs} wsConnected={true} />
             )
 
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=passed')
-        })
-
-        it('should handle navigation with special characters in filter', async () => {
-            const user = userEvent.setup()
-
-            renderWithRouter(
-                <Header
-                    currentView="dashboard"
-                    onViewChange={mockOnViewChange}
-                    wsConnected={true}
-                />,
-                ['/?filter=failed&other=value%20with%20spaces']
-            )
-
-            const testsButton = screen.getByText('Tests')
-            await user.click(testsButton)
-
-            expect(mockNavigate).toHaveBeenCalledWith('/tests?filter=failed')
+            expect(screen.getAllByText('All Tests').length).toBeGreaterThan(0)
+            expect(screen.getAllByText('Frontend').length).toBeGreaterThan(0)
         })
     })
 })

--- a/scripts/trigger-test-run.js
+++ b/scripts/trigger-test-run.js
@@ -144,6 +144,13 @@ async function makeRequest(url, options = {}) {
                 throw error
             }
 
+            if (response.status === 423 && data.code === 'CI_AUTORUN_PAUSED') {
+                const error = new Error(data.message || 'CI auto-run is paused')
+                error.code = 'CI_AUTORUN_PAUSED'
+                error.data = data
+                throw error
+            }
+
             throw new Error(data.message || `HTTP ${response.status}: ${response.statusText}`)
         }
 
@@ -209,7 +216,7 @@ async function triggerTestRun(baseUrl, token, maxWorkers) {
         const data = await makeRequest(`${baseUrl}/api/tests/run-all`, {
             method: 'POST',
             headers,
-            body: JSON.stringify({maxWorkers}),
+            body: JSON.stringify({maxWorkers, source: 'script'}),
         })
 
         if (data.status === 'success' || data.success) {
@@ -243,6 +250,25 @@ async function triggerTestRun(baseUrl, token, maxWorkers) {
             }
 
             process.exit(2) // Exit with code 2 for "already running"
+        }
+
+        if (error.code === 'CI_AUTORUN_PAUSED') {
+            const resumeAt = error.data?.resumeAt
+            const resumeMsg = resumeAt
+                ? ` Resumes at ${new Date(resumeAt).toLocaleString()}.`
+                : ' No auto-resume scheduled.'
+            log(`CI auto-run is paused.${resumeMsg}`, 'warning')
+            if (config.silent) {
+                console.log(
+                    JSON.stringify({
+                        success: false,
+                        code: 'CI_AUTORUN_PAUSED',
+                        message: 'CI auto-run is paused',
+                        resumeAt,
+                    })
+                )
+            }
+            process.exit(2)
         }
 
         exitWithError(`Failed to trigger test run: ${error.message}`, 1)


### PR DESCRIPTION
- Implemented endpoints for managing project tab configurations, allowing users to set and retrieve tab settings.
- Introduced CI auto-run pause feature, enabling users to temporarily halt CI-triggered test runs with a specified resume time.
- Updated database schema to include a project column in test results and added migration logic for existing databases.
- Enhanced the TestService to handle project metadata and integrate with the new settings.
- Added tests to ensure the correct functionality of project tab configurations and CI auto-run pause features.