### PR TITLE
refactor: Remove temporary diagnostic logging from app and Playwright…

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -6,7 +6,6 @@ import {errorHandler, notFoundHandler} from './middleware/error.middleware'
 import {createServiceContainer, injectServices} from './middleware/service-injection.middleware'
 import {createAuthMiddleware} from './middleware/auth.middleware'
 import {createApiRoutes} from './routes/index.routes'
-import {Logger} from './utils/logger.util'
 
 export async function createApp() {
     const app = express()
@@ -18,16 +17,6 @@ export async function createApp() {
     app.use(corsMiddleware)
     app.use(express.json({limit: config.api.requestLimit}))
     app.use(express.urlencoded({extended: true, limit: config.api.requestLimit}))
-
-    // Temporary diagnostic: log all POST requests to /api/tests
-    app.use((req, _res, next) => {
-        if (req.method === 'POST' && req.path.startsWith('/api/tests')) {
-            Logger.debug(
-                `[DIAG] POST ${req.path} received, body keys: ${Object.keys(req.body || {}).join(', ')}`
-            )
-        }
-        next()
-    })
 
     // Service injection middleware
     app.use(injectServices(serviceContainer))

--- a/packages/server/src/services/playwright.service.ts
+++ b/packages/server/src/services/playwright.service.ts
@@ -179,16 +179,6 @@ export class PlaywrightService implements IPlaywrightService {
             },
         })
 
-        // Log reporter stdout/stderr to diagnose sendTestResult failures
-        process.stdout?.on('data', (data: Buffer) => {
-            const text = data.toString().trim()
-            if (text) Logger.debug(`[REPORTER-OUT] ${text}`)
-        })
-        process.stderr?.on('data', (data: Buffer) => {
-            const text = data.toString().trim()
-            if (text) Logger.debug(`[REPORTER-ERR] ${text}`)
-        })
-
         return {
             runId,
             message: 'Test rerun started',


### PR DESCRIPTION
…Service

- Eliminated middleware for logging POST requests to /api/tests to streamline request handling.
- Removed stdout and stderr logging for the reporter in PlaywrightService to clean up the output and focus on essential logging.