### PR TITLE
feat: Implement project-specific test discovery and data management

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -23,6 +23,10 @@ Write tests in: `packages/{package}/src/__tests__/`
 `git stash` stashes ALL WIP and may lose in-progress work.  
 Instead: `npx vitest run path/to/test.ts` — if it fails without touching that file, it's pre-existing.
 
+## Run vitest from the repo root, not from a package directory
+
+`cd packages/server && npx vitest run ...` fails with "Projects definition references a non-existing file" — the root `vitest.config.ts` defines workspace projects. Run from repo root with a path filter instead: `npx vitest run packages/server/src/services/__tests__/foo.test.ts`, or `npx vitest run --project server --project web` for full suites.
+
 ## useSearchParams in web tests requires MemoryRouter
 
 ```tsx

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ Thumbs.db
 packages/server/test-results/
 .turbo/cookies
 .env.production
+runScript.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,11 @@ Full catalog with examples: [docs/ai/ANTI_PATTERNS.md](docs/ai/ANTI_PATTERNS.md)
 - **N+1 over JOIN** — `getTestResultsByTestId` already JOINs attachments+notes; don't loop & re-query
 - **Change without checking dependents** — grep all usages + tests before changing any value/default
 - **tsx watch stale** — restart server after significant changes; symptom: new routes return 404 while old return 401
-- **Playwright JSON not project-grouped** — top-level suites are per-FILE; project name at `spec.tests[0].projectName`
+- **Playwright JSON not project-grouped** — top-level suites are per-FILE; project name at `spec.tests[0].projectName`. Suite nesting depth is arbitrary (file > describe > nested describe > ...) — traverse recursively, not at fixed levels; a 2-level traversal silently drops deeper-nested tests.
 - **Reporter changes without npm link** — changes to `packages/reporter/src/` only apply via `npm link` or publish
 - **Rerun reporter output invisible** — `type: 'rerun'` uses `stdio: pipe` but has no listeners by default; add `process.stdout?.on('data', ...)` to rerun process temporarily to see reporter warnings (e.g. `⚠️ Failed to send test result`)
+- **testId has no project dimension** — hash is `filePath:title` only. `test_notes`/`note_images` are keyed by `test_id` alone (no `project` column) — any per-project feature (discovery, clear-data) must scope via `test_results.project`, not testId, and can't cleanly scope notes if two projects share a file+title.
+- **`activeProcessesTracker` run-all lock is global by design** — one active run blocks ALL projects, not just one. Intentional: concurrent Playwright processes conflict and the reporter drops results. Don't "fix" this to be per-project.
 
 **Frontend rules (auto-loaded for packages/web/**):** [.claude/rules/frontend.md](.claude/rules/frontend.md)  
 **Testing rules (auto-loaded for test files):\*\* [.claude/rules/testing.md](.claude/rules/testing.md)
@@ -166,7 +168,7 @@ Run via `@validation-agent` or manually.
 
 Blocks `source: 'script'` calls (from `trigger-test-run.js`) — UI-triggered runs still work.  
 HTTP 423 `CI_AUTORUN_PAUSED` → script exits code 2 (no retry). HTTP 409 `TESTS_ALREADY_RUNNING` → polls 10s, max 30 min.  
-Two `useCIAutoRun()` instances don't share state — `App.tsx` calls `reload()` on Settings close.
+Settings-modal hooks don't share state with their `App.tsx` instance (separate `useCIAutoRun()`/`useProjectTabs()` calls) — `App.tsx` must call each hook's `reload()` on Settings close, or changes (pause state, tab order/rename/visibility) look "stuck" until a full page refresh.
 
 ---
 

--- a/docs/TODO/TODO.md
+++ b/docs/TODO/TODO.md
@@ -2,9 +2,8 @@
 
 ## ToDo
 
+- Doscover for specific project
 - testModalWindow - attachments loader doesn't centered
-- remove "threshold is 15%"
-- Search field as in QA Lens (with cmd+k) + search by note text (if is not difficult?)
 
 - ⚠️ ALLOWED_ORIGINS not set in production - allowing all origins (not recommended)
 

--- a/packages/server/src/controllers/__tests__/test.controller.test.ts
+++ b/packages/server/src/controllers/__tests__/test.controller.test.ts
@@ -82,6 +82,7 @@ describe('TestController', () => {
             deleteTest: vi.fn(),
             deleteExecution: vi.fn(),
             clearAllTests: vi.fn(),
+            clearProjectData: vi.fn(),
             saveTestResult: vi.fn(),
             getTestById: vi.fn(),
             rerunTest: vi.fn(),
@@ -125,6 +126,16 @@ describe('TestController', () => {
             expect(mockTestService.discoverTests).toHaveBeenCalledTimes(1)
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, discoveryResult)
             expect(Logger.error).not.toHaveBeenCalled()
+        })
+
+        it('should scope discovery to the project from the request body when provided', async () => {
+            const discoveryResult = {discovered: 3, saved: 3, timestamp: '2025-01-01T00:00:00Z'}
+            mockTestService.discoverTests.mockResolvedValue(discoveryResult)
+            mockReq.body = {project: 'Frontend'}
+
+            await controller.discoverTests(mockReq as ServiceRequest, mockRes as Response)
+
+            expect(mockTestService.discoverTests).toHaveBeenCalledWith('Frontend')
         })
 
         it('should handle discovery errors', async () => {
@@ -543,6 +554,21 @@ describe('TestController', () => {
             expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, {
                 message: 'All test data cleared successfully',
                 statsBefore,
+            })
+        })
+
+        it('should clear only the given project when ?project= is provided', async () => {
+            mockTestService.clearProjectData.mockResolvedValue({deletedExecutions: 30})
+            mockReq.query = {project: 'API_Tests'}
+
+            await controller.clearAllTests(mockReq as ServiceRequest, mockRes as Response)
+
+            expect(mockTestService.clearProjectData).toHaveBeenCalledWith('API_Tests')
+            expect(mockTestService.clearAllTests).not.toHaveBeenCalled()
+            expect(mockTestService.getTestStats).not.toHaveBeenCalled()
+            expect(ResponseHelper.success).toHaveBeenCalledWith(mockRes, {
+                message: 'Test data for project "API_Tests" cleared successfully',
+                deletedExecutions: 30,
             })
         })
 

--- a/packages/server/src/controllers/test.controller.ts
+++ b/packages/server/src/controllers/test.controller.ts
@@ -15,10 +15,11 @@ export class TestController {
         private authService: AuthService
     ) {}
 
-    // POST /api/tests/discovery - Discover all available tests
+    // POST /api/tests/discovery - Discover tests (optionally scoped to a single project)
     discoverTests = async (req: ServiceRequest, res: Response): Promise<Response> => {
         try {
-            const result = await this.testService.discoverTests()
+            const {project} = req.body
+            const result = await this.testService.discoverTests(project)
             return ResponseHelper.success(res, result)
         } catch (error) {
             Logger.error('Error during test discovery', error)
@@ -266,9 +267,20 @@ export class TestController {
         }
     }
 
-    // DELETE /api/tests/all - Clear all test data
+    // DELETE /api/tests/all - Clear all test data (optionally scoped to ?project=)
     clearAllTests = async (req: ServiceRequest, res: Response): Promise<Response> => {
         try {
+            const project = typeof req.query.project === 'string' ? req.query.project : undefined
+
+            if (project) {
+                const {deletedExecutions} = await this.testService.clearProjectData(project)
+
+                return ResponseHelper.success(res, {
+                    message: `Test data for project "${project}" cleared successfully`,
+                    deletedExecutions,
+                })
+            }
+
             const statsBefore = await this.testService.getTestStats()
             await this.testService.clearAllTests()
 

--- a/packages/server/src/repositories/__tests__/test.repository.test.ts
+++ b/packages/server/src/repositories/__tests__/test.repository.test.ts
@@ -965,6 +965,92 @@ describe('TestRepository - Core Functionality', () => {
         })
     })
 
+    describe('per-project bulk clear', () => {
+        it('getExecutionIdsByProject() returns only ids for the given project', async () => {
+            const apiResult = createTestResult('test-api-1', 'passed', {project: 'API_Tests'})
+            const stagingResult = createTestResult('test-staging-1', 'passed', {
+                project: 'Staging',
+            })
+            await repository.saveTestResult(apiResult)
+            await repository.saveTestResult(stagingResult)
+
+            const ids = await repository.getExecutionIdsByProject('API_Tests')
+
+            expect(ids).toEqual([apiResult.id])
+        })
+
+        it('getDistinctTestIdsByProject() dedupes testIds within a project', async () => {
+            await repository.saveTestResult(
+                createTestResult('test-api-1', 'passed', {project: 'API_Tests'})
+            )
+            await repository.saveTestResult(
+                createTestResult('test-api-1', 'failed', {project: 'API_Tests'})
+            )
+            await repository.saveTestResult(
+                createTestResult('test-staging-1', 'passed', {project: 'Staging'})
+            )
+
+            const testIds = await repository.getDistinctTestIdsByProject('API_Tests')
+
+            expect(testIds).toEqual(['test-api-1'])
+        })
+
+        it('deleteByProject() deletes only that project and leaves others intact', async () => {
+            await repository.saveTestResult(
+                createTestResult('test-api-1', 'passed', {project: 'API_Tests'})
+            )
+            await repository.saveTestResult(
+                createTestResult('test-staging-1', 'passed', {project: 'Staging'})
+            )
+
+            const deletedCount = await repository.deleteByProject('API_Tests')
+
+            expect(deletedCount).toBe(1)
+            expect(await repository.getExecutionIdsByProject('API_Tests')).toEqual([])
+            expect(await repository.getExecutionIdsByProject('Staging')).toHaveLength(1)
+        })
+
+        it('deleteByProject() cascade deletes attachments for that project only', async () => {
+            const apiResult = createTestResult('test-api-1', 'passed', {project: 'API_Tests'})
+            const apiResultId = await repository.saveTestResult(apiResult)
+            const stagingResult = createTestResult('test-staging-1', 'passed', {
+                project: 'Staging',
+            })
+            const stagingResultId = await repository.saveTestResult(stagingResult)
+
+            await attachmentRepository.saveAttachment({
+                id: `att-${Date.now()}-api`,
+                testResultId: apiResultId,
+                type: 'screenshot',
+                fileName: 'api.png',
+                filePath: '/path/to/api.png',
+                fileSize: 1024,
+                url: '/attachments/api.png',
+            })
+            await attachmentRepository.saveAttachment({
+                id: `att-${Date.now()}-staging`,
+                testResultId: stagingResultId,
+                type: 'screenshot',
+                fileName: 'staging.png',
+                filePath: '/path/to/staging.png',
+                fileSize: 1024,
+                url: '/attachments/staging.png',
+            })
+
+            await repository.deleteByProject('API_Tests')
+
+            // CASCADE removed the API_Tests attachment...
+            expect(await attachmentRepository.getAttachmentsByTestResult(apiResultId)).toHaveLength(
+                0
+            )
+            // ...but left the Staging attachment (and row) untouched
+            expect(
+                await attachmentRepository.getAttachmentsByTestResult(stagingResultId)
+            ).toHaveLength(1)
+            expect(await repository.getExecutionIdsByProject('Staging')).toEqual([stagingResultId])
+        })
+    })
+
     describe('deleteByTestId()', () => {
         it('should delete all executions for a specific testId', async () => {
             const testId = 'test-to-delete'

--- a/packages/server/src/repositories/test.repository.ts
+++ b/packages/server/src/repositories/test.repository.ts
@@ -193,6 +193,33 @@ export class TestRepository extends BaseRepository implements ITestRepository {
         return row?.project ?? ''
     }
 
+    async getExecutionIdsByProject(project: string): Promise<string[]> {
+        const rows = await this.queryAll<{id: string}>(
+            `SELECT id FROM test_results WHERE project = ?`,
+            [project]
+        )
+        return rows.map((r) => r.id)
+    }
+
+    async getDistinctTestIdsByProject(project: string): Promise<string[]> {
+        const rows = await this.queryAll<{test_id: string}>(
+            `SELECT DISTINCT test_id FROM test_results WHERE project = ?`,
+            [project]
+        )
+        return rows.map((r) => r.test_id)
+    }
+
+    async deleteByProject(project: string): Promise<number> {
+        const result = await this.dbManager.execute(`DELETE FROM test_results WHERE project = ?`, [
+            project,
+        ])
+
+        // Compact database to reclaim space after deletion
+        await this.dbManager.compactDatabase()
+
+        return result.changes || 0
+    }
+
     async getFlakyTests(days: number = 30, thresholdPercent: number = 10): Promise<any[]> {
         const sql = `
             SELECT

--- a/packages/server/src/services/__tests__/playwright.service.test.ts
+++ b/packages/server/src/services/__tests__/playwright.service.test.ts
@@ -121,6 +121,25 @@ describe('PlaywrightService', () => {
             )
         })
 
+        it('should pass --project flag when scoping discovery to a single project', async () => {
+            // Arrange
+            const mockPlaywrightOutput = {suites: []}
+            mockSpawn.mockReturnValue(createMockProcess(JSON.stringify(mockPlaywrightOutput)))
+
+            // Act
+            await service.discoverTests('chromium')
+
+            // Assert
+            expect(mockSpawn).toHaveBeenCalledWith(
+                'npx',
+                ['playwright', 'test', '--list', '--reporter=json', '--project=chromium'],
+                expect.objectContaining({
+                    cwd: '/test/project',
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                })
+            )
+        })
+
         it('should discover tests from nested suites', async () => {
             // Arrange
             const mockPlaywrightOutput = {
@@ -155,6 +174,46 @@ describe('PlaywrightService', () => {
             expect(tests).toHaveLength(2)
             expect(tests[0].name).toBe('nested test 1')
             expect(tests[0].filePath).toBe('nested/test.spec.ts')
+        })
+
+        it('should discover tests nested 3+ levels deep (file > describe > nested describe > test)', async () => {
+            // Arrange - mirrors real-world configs where describe blocks nest inside
+            // describe blocks, e.g. api-tests/accounts/accounts.api.test.ts:
+            // "Accounts API" > "POST /accounts/accountCompany" > test
+            const mockPlaywrightOutput = {
+                suites: [
+                    {
+                        title: 'api-tests/accounts/accounts.api.test.ts',
+                        suites: [
+                            {
+                                title: 'Accounts API',
+                                suites: [
+                                    {
+                                        title: 'POST /accounts/accountCompany',
+                                        specs: [
+                                            {
+                                                title: 'creates main contractor company for account',
+                                                file: 'api-tests/accounts/accounts.api.test.ts',
+                                                line: 12,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            mockSpawn.mockReturnValue(createMockProcess(JSON.stringify(mockPlaywrightOutput)))
+
+            // Act
+            const tests = await service.discoverTests('API_Tests')
+
+            // Assert
+            expect(tests).toHaveLength(1)
+            expect(tests[0].name).toBe('creates main contractor company for account')
+            expect(tests[0].filePath).toBe('api-tests/accounts/accounts.api.test.ts')
         })
 
         it('should discover tests from both top-level and nested suites', async () => {

--- a/packages/server/src/services/__tests__/test.service.test.ts
+++ b/packages/server/src/services/__tests__/test.service.test.ts
@@ -83,6 +83,9 @@ describe('TestService', () => {
             getAttachmentsSizeForIds: vi.fn().mockResolvedValue({total: 0, perId: {}}),
             deleteByIds: vi.fn().mockResolvedValue(0),
             getProjectByFilePath: vi.fn().mockResolvedValue(''),
+            getExecutionIdsByProject: vi.fn().mockResolvedValue([]),
+            getDistinctTestIdsByProject: vi.fn().mockResolvedValue([]),
+            deleteByProject: vi.fn().mockResolvedValue(0),
         }
 
         mockRunRepository = {
@@ -200,7 +203,11 @@ describe('TestService', () => {
             expect(mockTestRepository.saveTestResult).toHaveBeenCalledTimes(2)
 
             // Verify WebSocket broadcast
-            expect(mockWebSocketService.broadcastDiscoveryCompleted).toHaveBeenCalledWith(2, 2)
+            expect(mockWebSocketService.broadcastDiscoveryCompleted).toHaveBeenCalledWith(
+                2,
+                2,
+                undefined
+            )
         })
 
         it('should continue if some tests fail to save', async () => {
@@ -231,7 +238,11 @@ describe('TestService', () => {
 
             expect(result.discovered).toBe(2)
             expect(result.saved).toBe(1) // Only 1 saved successfully
-            expect(mockWebSocketService.broadcastDiscoveryCompleted).toHaveBeenCalledWith(2, 1)
+            expect(mockWebSocketService.broadcastDiscoveryCompleted).toHaveBeenCalledWith(
+                2,
+                1,
+                undefined
+            )
         })
 
         it('should throw error if discovery fails', async () => {
@@ -245,6 +256,25 @@ describe('TestService', () => {
             mockTestRepository.execute.mockRejectedValue(new Error('DB error'))
 
             await expect(testService.discoverTests()).rejects.toThrow('DB error')
+        })
+
+        it('should scope pending-cleanup, Playwright discovery, and broadcast to a single project when provided', async () => {
+            mockTestRepository.execute.mockResolvedValue(undefined)
+            mockPlaywrightService.discoverTests.mockResolvedValue([])
+            mockTestRepository.saveTestResult.mockResolvedValue('saved-id')
+
+            await testService.discoverTests('chromium')
+
+            expect(mockTestRepository.execute).toHaveBeenCalledWith(
+                'DELETE FROM test_results WHERE status = ? AND project = ?',
+                ['pending', 'chromium']
+            )
+            expect(mockPlaywrightService.discoverTests).toHaveBeenCalledWith('chromium')
+            expect(mockWebSocketService.broadcastDiscoveryCompleted).toHaveBeenCalledWith(
+                0,
+                0,
+                'chromium'
+            )
         })
     })
 
@@ -661,6 +691,58 @@ describe('TestService', () => {
         })
     })
 
+    describe('clearProjectData', () => {
+        it('should delete attachments and notes per test, then bulk-delete by project', async () => {
+            mockTestRepository.getExecutionIdsByProject.mockResolvedValue(['exec-1', 'exec-2'])
+            mockTestRepository.getDistinctTestIdsByProject.mockResolvedValue(['test-1', 'test-2'])
+            mockTestRepository.deleteByProject.mockResolvedValue(2)
+            mockAttachmentService.deleteAttachmentsForTestResult.mockResolvedValue(0)
+            mockNoteService.deleteNote.mockResolvedValue(undefined)
+
+            const result = await testService.clearProjectData('API_Tests')
+
+            expect(mockTestRepository.getExecutionIdsByProject).toHaveBeenCalledWith('API_Tests')
+            expect(mockTestRepository.getDistinctTestIdsByProject).toHaveBeenCalledWith('API_Tests')
+            expect(mockAttachmentService.deleteAttachmentsForTestResult).toHaveBeenCalledWith(
+                'exec-1'
+            )
+            expect(mockAttachmentService.deleteAttachmentsForTestResult).toHaveBeenCalledWith(
+                'exec-2'
+            )
+            expect(mockNoteService.deleteNote).toHaveBeenCalledWith('test-1')
+            expect(mockNoteService.deleteNote).toHaveBeenCalledWith('test-2')
+            expect(mockTestRepository.deleteByProject).toHaveBeenCalledWith('API_Tests')
+            expect(result).toEqual({deletedExecutions: 2})
+        })
+
+        it('should not touch other projects data (only deleteByProject with the given project)', async () => {
+            mockTestRepository.getExecutionIdsByProject.mockResolvedValue([])
+            mockTestRepository.getDistinctTestIdsByProject.mockResolvedValue([])
+            mockTestRepository.deleteByProject.mockResolvedValue(0)
+
+            await testService.clearProjectData('Staging')
+
+            expect(mockTestRepository.clearAllTests).not.toHaveBeenCalled()
+            expect(mockAttachmentService.deleteAttachmentsForTestResult).not.toHaveBeenCalled()
+            expect(mockTestRepository.deleteByProject).toHaveBeenCalledWith('Staging')
+        })
+
+        it('should continue clearing even if an attachment or note deletion fails', async () => {
+            mockTestRepository.getExecutionIdsByProject.mockResolvedValue(['exec-1'])
+            mockTestRepository.getDistinctTestIdsByProject.mockResolvedValue(['test-1'])
+            mockAttachmentService.deleteAttachmentsForTestResult.mockRejectedValue(
+                new Error('disk error')
+            )
+            mockNoteService.deleteNote.mockRejectedValue(new Error('note error'))
+            mockTestRepository.deleteByProject.mockResolvedValue(1)
+
+            const result = await testService.clearProjectData('API_Tests')
+
+            expect(mockTestRepository.deleteByProject).toHaveBeenCalledWith('API_Tests')
+            expect(result).toEqual({deletedExecutions: 1})
+        })
+    })
+
     describe('getTestStats', () => {
         it('should get database statistics', async () => {
             const mockStats = {
@@ -826,6 +908,34 @@ describe('TestService', () => {
 
             // Assert - global settings used as fallback
             expect(mockPlaywrightService.runAllTests).toHaveBeenCalledWith(2, 'Sanity')
+        })
+
+        it('should scope auto-discovery to the Settings-configured project for CI script triggers', async () => {
+            // Mirrors scripts/trigger-test-run.js, which posts {maxWorkers, source: 'script'}
+            // with no project and no skipAutoDiscovery — relying entirely on the
+            // Settings-configured global_playwright_project as the scope.
+            const mockProcess = createMockProcess()
+            mockSettingsService.getGlobalPlaywrightProject.mockResolvedValue('API_Tests')
+            mockSettingsService.getCIAutoRunPause = vi.fn().mockResolvedValue({paused: false})
+            mockPlaywrightService.discoverTests.mockResolvedValue([])
+            mockPlaywrightService.runAllTests.mockResolvedValue({
+                runId: 'run-ci-1',
+                message: 'Tests started for project: API_Tests',
+                timestamp: '2025-10-21T10:00:00.000Z',
+                process: mockProcess,
+            })
+            mockRunRepository.createTestRun.mockResolvedValue('run-ci-1')
+
+            await testService.runAllTests(undefined, undefined, undefined, 'script')
+
+            // Discovery (and its pending-cleanup DELETE) must be scoped to the same
+            // project the run itself uses — never a global, cross-project reset.
+            expect(mockPlaywrightService.discoverTests).toHaveBeenCalledWith('API_Tests')
+            expect(mockTestRepository.execute).toHaveBeenCalledWith(
+                'DELETE FROM test_results WHERE status = ? AND project = ?',
+                ['pending', 'API_Tests']
+            )
+            expect(mockPlaywrightService.runAllTests).toHaveBeenCalledWith(undefined, 'API_Tests')
         })
 
         it('should pass undefined project when no global project is configured', async () => {

--- a/packages/server/src/services/playwright.service.ts
+++ b/packages/server/src/services/playwright.service.ts
@@ -6,6 +6,7 @@ import {IPlaywrightService, TestRunProcess, DiscoveredTest} from '../types/servi
 import {
     PlaywrightListOutput,
     PlaywrightSpec,
+    PlaywrightSuite,
     PlaywrightSpawnOptions,
     ValidationResult,
 } from '../types/playwright.types'
@@ -18,13 +19,13 @@ export class PlaywrightService implements IPlaywrightService {
     // TEST DISCOVERY & EXECUTION
     // ============================================================================
 
-    async discoverTests(): Promise<DiscoveredTest[]> {
-        Logger.info('Discovering tests', {projectDir: config.playwright.projectDir})
+    async discoverTests(project?: string): Promise<DiscoveredTest[]> {
+        Logger.info('Discovering tests', {projectDir: config.playwright.projectDir, project})
 
         let playwrightData: PlaywrightListOutput
 
         try {
-            playwrightData = await this.executePlaywrightListCommand()
+            playwrightData = await this.executePlaywrightListCommand(project)
         } catch (error) {
             throw new Error(
                 `Test discovery failed: ${error instanceof Error ? error.message : 'Unknown error'}. ` +
@@ -34,23 +35,21 @@ export class PlaywrightService implements IPlaywrightService {
 
         const discoveredTests: DiscoveredTest[] = []
 
-        // Extract all tests from both top-level and nested structures.
+        // Suites nest arbitrarily deep (file > describe > nested describe > ...),
+        // so specs must be collected recursively rather than at fixed levels.
         // Project comes from spec.tests[0].projectName (Playwright JSON reporter field).
-        for (const suite of playwrightData.suites || []) {
-            // Handle top-level specs directly under the suite
-            for (const spec of suite.specs || []) {
-                discoveredTests.push(this.createDiscoveredTest(spec))
-            }
-
-            // Handle nested specs within sub-suites
-            for (const subSuite of suite.suites || []) {
-                for (const spec of subSuite.specs || []) {
-                    discoveredTests.push(this.createDiscoveredTest(spec))
-                }
-            }
-        }
+        this.collectSpecs(playwrightData.suites || [], discoveredTests)
 
         return discoveredTests
+    }
+
+    private collectSpecs(suites: PlaywrightSuite[] | undefined, out: DiscoveredTest[]): void {
+        for (const suite of suites || []) {
+            for (const spec of suite.specs || []) {
+                out.push(this.createDiscoveredTest(spec))
+            }
+            this.collectSpecs(suite.suites, out)
+        }
     }
 
     async getAvailableProjects(): Promise<string[]> {
@@ -369,21 +368,21 @@ export class PlaywrightService implements IPlaywrightService {
     /**
      * Executes the playwright test --list command and returns parsed JSON output
      */
-    private async executePlaywrightListCommand(): Promise<PlaywrightListOutput> {
+    private async executePlaywrightListCommand(project?: string): Promise<PlaywrightListOutput> {
         return new Promise((resolve, reject) => {
-            const process = spawn(
-                'npx',
-                [
-                    'playwright',
-                    'test',
-                    '--list',
-                    `--reporter=${PLAYWRIGHT_CONSTANTS.LIST_REPORTER}`,
-                ],
-                {
-                    cwd: config.playwright.projectDir,
-                    stdio: ['ignore', 'pipe', 'pipe'],
-                }
-            )
+            const args = [
+                'playwright',
+                'test',
+                '--list',
+                `--reporter=${PLAYWRIGHT_CONSTANTS.LIST_REPORTER}`,
+            ]
+            if (project) {
+                args.push(`--project=${project}`)
+            }
+            const process = spawn('npx', args, {
+                cwd: config.playwright.projectDir,
+                stdio: ['ignore', 'pipe', 'pipe'],
+            })
 
             let stdout = ''
             let stderr = ''

--- a/packages/server/src/services/test.service.ts
+++ b/packages/server/src/services/test.service.ts
@@ -35,15 +35,24 @@ export class TestService implements ITestService {
         return project || undefined
     }
 
-    async discoverTests(): Promise<TestDiscoveryResult> {
+    async discoverTests(project?: string): Promise<TestDiscoveryResult> {
         try {
-            // Clear existing pending tests before adding discovered ones
-            await this.testRepository['execute']('DELETE FROM test_results WHERE status = ?', [
-                'pending',
-            ])
+            // Clear existing pending tests before adding discovered ones.
+            // Scoped to a single project when provided, so discovering/running one
+            // project's tests never resets pending status for other project tabs.
+            if (project) {
+                await this.testRepository['execute'](
+                    'DELETE FROM test_results WHERE status = ? AND project = ?',
+                    ['pending', project]
+                )
+            } else {
+                await this.testRepository['execute']('DELETE FROM test_results WHERE status = ?', [
+                    'pending',
+                ])
+            }
 
             // Discover tests using Playwright
-            const discoveredTests = await this.playwrightService.discoverTests()
+            const discoveredTests = await this.playwrightService.discoverTests(project)
 
             // Save discovered tests to database
             let savedCount = 0
@@ -57,7 +66,11 @@ export class TestService implements ITestService {
             }
 
             // Broadcast discovery update via WebSocket
-            this.websocketService.broadcastDiscoveryCompleted(discoveredTests.length, savedCount)
+            this.websocketService.broadcastDiscoveryCompleted(
+                discoveredTests.length,
+                savedCount,
+                project
+            )
 
             Logger.testDiscovery(discoveredTests.length, savedCount)
 
@@ -149,6 +162,38 @@ export class TestService implements ITestService {
         Logger.info(`Deleted execution ${executionId}`)
 
         return {success: true}
+    }
+
+    async clearProjectData(project: string): Promise<{deletedExecutions: number}> {
+        // Get all executions and distinct test_ids for this project up front,
+        // since deleting test_results rows first would make them unrecoverable.
+        const executionIds = await this.testRepository.getExecutionIdsByProject(project)
+        const testIds = await this.testRepository.getDistinctTestIdsByProject(project)
+
+        // Delete physical attachment files for each execution
+        for (const executionId of executionIds) {
+            try {
+                await this.attachmentService.deleteAttachmentsForTestResult(executionId)
+            } catch (error) {
+                Logger.error(`Failed to delete attachments for execution ${executionId}`, error)
+            }
+        }
+
+        // Delete test notes for each test in this project
+        for (const testId of testIds) {
+            try {
+                await this.noteService.deleteNote(testId)
+            } catch (error) {
+                Logger.error(`Failed to delete note for test ${testId}`, error)
+            }
+        }
+
+        // Delete all test_results records for this project (CASCADE will delete attachment records)
+        const deletedCount = await this.testRepository.deleteByProject(project)
+
+        Logger.info(`Cleared project ${project}: ${deletedCount} executions`)
+
+        return {deletedExecutions: deletedCount}
     }
 
     async clearAllTests(): Promise<void> {
@@ -363,15 +408,17 @@ export class TestService implements ITestService {
             }
         }
 
-        // Auto-discover tests before running unless explicitly skipped
-        if (!skipAutoDiscovery) {
-            await this.discoverTests()
-        }
-
         const project =
             requestedProject !== undefined && requestedProject !== ''
                 ? requestedProject
                 : await this.getExecutionProject()
+
+        // Auto-discover tests before running unless explicitly skipped.
+        // Scoped to the resolved project so this never resets other projects' pending status.
+        if (!skipAutoDiscovery) {
+            await this.discoverTests(project)
+        }
+
         const result = await this.playwrightService.runAllTests(maxWorkers, project)
 
         // Add process to tracker

--- a/packages/server/src/services/websocket.service.ts
+++ b/packages/server/src/services/websocket.service.ts
@@ -33,12 +33,13 @@ export class WebSocketService implements IWebSocketService {
         })
     }
 
-    broadcastDiscoveryCompleted(total: number, saved: number): void {
+    broadcastDiscoveryCompleted(total: number, saved: number, project?: string): void {
         this.broadcast({
             type: 'discovery:completed',
             data: {
                 total,
                 saved,
+                project,
                 timestamp: new Date().toISOString(),
             },
         })

--- a/packages/server/src/types/service.types.ts
+++ b/packages/server/src/types/service.types.ts
@@ -3,7 +3,7 @@ import {TestResultData, TestRunData, AttachmentData} from './database.types'
 
 // Service interfaces
 export interface ITestService {
-    discoverTests(): Promise<TestDiscoveryResult>
+    discoverTests(project?: string): Promise<TestDiscoveryResult>
     getAllTests(filters: TestFilters): Promise<TestResult[]>
     getTestById(id: string): Promise<TestResult | null>
     getTestHistory(testId: string, limit?: number, before?: string): Promise<TestResult[]>
@@ -11,6 +11,7 @@ export interface ITestService {
     deleteTest(testId: string): Promise<{deletedExecutions: number}>
     deleteExecution(executionId: string): Promise<{success: boolean}>
     clearAllTests(): Promise<void>
+    clearProjectData(project: string): Promise<{deletedExecutions: number}>
     cleanupData(options: CleanupOptions): Promise<CleanupResult>
     saveTestResult(testData: TestResultData): Promise<string>
     getTestStats(): Promise<DatabaseStats>
@@ -34,7 +35,7 @@ export interface CleanupResult {
 }
 
 export interface IPlaywrightService {
-    discoverTests(): Promise<DiscoveredTest[]>
+    discoverTests(project?: string): Promise<DiscoveredTest[]>
     getAvailableProjects(): Promise<string[]>
     runAllTests(maxWorkers?: number, project?: string): Promise<TestRunProcess>
     runTestGroup(
@@ -146,6 +147,10 @@ export interface ITestRepository {
     getAttachmentsSizeForIds(ids: string[]): Promise<{total: number; perId: Record<string, number>}>
     deleteByIds(ids: string[]): Promise<number>
     getProjectByFilePath(filePath: string): Promise<string>
+    // Per-project bulk clear ("Clear Project Data")
+    getExecutionIdsByProject(project: string): Promise<string[]>
+    getDistinctTestIdsByProject(project: string): Promise<string[]>
+    deleteByProject(project: string): Promise<number>
 }
 
 export interface IRunRepository {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -46,7 +46,11 @@ function App() {
         return params.get('project') || ''
     }, [location.search])
 
-    const {visibleTabs, isLoading: tabsLoading} = useProjectTabs(isAuthenticated)
+    const {
+        visibleTabs,
+        isLoading: tabsLoading,
+        reload: reloadProjectTabs,
+    } = useProjectTabs(isAuthenticated)
 
     const {
         fetchTests,
@@ -283,8 +287,10 @@ function App() {
                     setIsSettingsOpen(false)
                     setSettingsScrollToDataRetention(false)
                     void reloadCIAutoRun()
+                    void reloadProjectTabs()
                 }}
                 scrollToDataRetention={settingsScrollToDataRetention}
+                activeProject={activeProject || undefined}
             />
 
             {ciPause?.paused && (

--- a/packages/web/src/features/dashboard/components/settings/SettingsActionsSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsActionsSection.tsx
@@ -1,15 +1,24 @@
-import {Search, HeartPulse, Trash2} from 'lucide-react'
+import {Search, HeartPulse, Trash2, ChevronDown} from 'lucide-react'
+import {useRef, useState} from 'react'
 import {Button} from '@shared/components'
 import {config} from '@config/environment.config'
 import {useTestsStore} from '@features/tests/store/testsStore'
+import {useClickOutside} from '@/hooks/useClickOutside'
 import {useDashboardActions} from '../../hooks'
 import {SettingsSection} from './SettingsSection'
 
-export function SettingsActionsSection() {
+export interface SettingsActionsSectionProps {
+    activeProject?: string
+}
+
+export function SettingsActionsSection({activeProject}: SettingsActionsSectionProps) {
     const {discoverTests, isDiscovering, getIsAnyTestRunning} = useTestsStore()
 
     const {clearingData, clearAllData} = useDashboardActions()
     const isAnyTestRunning = getIsAnyTestRunning()
+    const [showClearMenu, setShowClearMenu] = useState(false)
+    const clearSplitRef = useRef<HTMLDivElement>(null)
+    useClickOutside(clearSplitRef, showClearMenu, () => setShowClearMenu(false))
 
     return (
         <SettingsSection title="Actions" description="Common tasks and operations">
@@ -19,7 +28,7 @@ export function SettingsActionsSection() {
                     fullWidth
                     loading={isDiscovering}
                     disabled={isAnyTestRunning}
-                    onClick={discoverTests}>
+                    onClick={() => discoverTests()}>
                     {isDiscovering ? (
                         'Discovering...'
                     ) : (
@@ -38,20 +47,52 @@ export function SettingsActionsSection() {
                     </span>
                 </Button>
 
-                <Button
-                    variant="danger"
-                    fullWidth
-                    loading={clearingData}
-                    disabled={isAnyTestRunning || clearingData}
-                    onClick={clearAllData}>
-                    {clearingData ? (
-                        'Clearing...'
-                    ) : (
-                        <span className="flex items-center gap-1.5">
-                            <Trash2 className="h-4 w-4" /> Clear All Data
-                        </span>
+                <div className="relative" ref={clearSplitRef}>
+                    <div className="flex rounded-xl shadow-soft">
+                        <Button
+                            variant="danger"
+                            fullWidth
+                            loading={clearingData}
+                            disabled={isAnyTestRunning || clearingData}
+                            onClick={() => {
+                                setShowClearMenu(false)
+                                clearAllData()
+                            }}
+                            className="rounded-r-none shadow-none">
+                            {clearingData ? (
+                                'Clearing...'
+                            ) : (
+                                <span className="flex items-center gap-1.5">
+                                    <Trash2 className="h-4 w-4" /> Clear All Data
+                                </span>
+                            )}
+                        </Button>
+                        <Button
+                            variant="danger"
+                            loading={false}
+                            disabled={isAnyTestRunning || clearingData || !activeProject}
+                            onClick={() => setShowClearMenu((open) => !open)}
+                            aria-label="Clear project data options"
+                            aria-expanded={showClearMenu}
+                            className="rounded-l-none shadow-none border-l border-white/20 px-2 dark:border-black/20">
+                            <ChevronDown className="h-4 w-4" />
+                        </Button>
+                    </div>
+                    {showClearMenu && activeProject && (
+                        <div className="absolute top-full left-0 z-50 mt-2 min-w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-gray-800">
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setShowClearMenu(false)
+                                    clearAllData(activeProject)
+                                }}
+                                className="flex w-full items-center gap-2 whitespace-nowrap px-4 py-2.5 text-left text-sm text-danger-600 hover:bg-gray-50 dark:text-danger-400 dark:hover:bg-white/[0.06]">
+                                <Trash2 className="h-3.5 w-3.5" />
+                                Clear "{activeProject}" data only
+                            </button>
+                        </div>
                     )}
-                </Button>
+                </div>
             </div>
         </SettingsSection>
     )

--- a/packages/web/src/features/dashboard/components/settings/SettingsModal.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsModal.tsx
@@ -11,9 +11,15 @@ export interface SettingsModalProps {
     isOpen: boolean
     onClose: () => void
     scrollToDataRetention?: boolean
+    activeProject?: string
 }
 
-export function SettingsModal({isOpen, onClose, scrollToDataRetention}: SettingsModalProps) {
+export function SettingsModal({
+    isOpen,
+    onClose,
+    scrollToDataRetention,
+    activeProject,
+}: SettingsModalProps) {
     const dataRetentionRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
@@ -53,7 +59,7 @@ export function SettingsModal({isOpen, onClose, scrollToDataRetention}: Settings
                         <SettingsThemeSection />
                         <SettingsProjectTabsSection />
                         <SettingsTestExecutionSection />
-                        <SettingsActionsSection />
+                        <SettingsActionsSection activeProject={activeProject} />
                         <div ref={dataRetentionRef}>
                             <SettingsStorageSection />
                         </div>

--- a/packages/web/src/features/dashboard/components/settings/SettingsProjectTabsSection.tsx
+++ b/packages/web/src/features/dashboard/components/settings/SettingsProjectTabsSection.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect} from 'react'
-import {RefreshCw} from 'lucide-react'
+import {RefreshCw, ChevronUp, ChevronDown} from 'lucide-react'
 import {useProjectTabs, ProjectTabConfig} from '@/hooks/useProjectTabs'
 import {SettingsSection} from './SettingsSection'
 
@@ -42,6 +42,17 @@ export function SettingsProjectTabsSection() {
         await updateTabs(updated)
     }
 
+    const handleMove = async (project: string, direction: 'up' | 'down') => {
+        const index = localTabs.findIndex((t) => t.project === project)
+        const targetIndex = direction === 'up' ? index - 1 : index + 1
+        if (index === -1 || targetIndex < 0 || targetIndex >= localTabs.length) return
+
+        const updated = [...localTabs]
+        ;[updated[index], updated[targetIndex]] = [updated[targetIndex], updated[index]]
+        setLocalTabs(updated)
+        await updateTabs(updated)
+    }
+
     const compactInputClass =
         'rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-sm text-gray-900 ' +
         'focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500/60 ' +
@@ -77,7 +88,10 @@ export function SettingsProjectTabsSection() {
                 {localTabs.length > 0 && (
                     <div className="space-y-2">
                         {/* Header row */}
-                        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-3 px-1">
+                        <div className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 px-1">
+                            <span className="text-xs font-medium text-gray-400 dark:text-gray-500 w-14">
+                                Order
+                            </span>
                             <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
                                 Project
                             </span>
@@ -89,10 +103,28 @@ export function SettingsProjectTabsSection() {
                             </span>
                         </div>
 
-                        {localTabs.map((tab) => (
+                        {localTabs.map((tab, index) => (
                             <div
                                 key={tab.project}
-                                className="grid grid-cols-[1fr_auto_auto] items-center gap-x-3 rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 dark:border-white/[0.06] dark:bg-white/[0.02]">
+                                className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 dark:border-white/[0.06] dark:bg-white/[0.02]">
+                                <div className="flex w-14 items-center gap-0.5">
+                                    <button
+                                        type="button"
+                                        aria-label={`Move ${tab.project} up`}
+                                        onClick={() => handleMove(tab.project, 'up')}
+                                        disabled={isSaving || index === 0}
+                                        className="rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 disabled:pointer-events-none disabled:opacity-30 dark:text-gray-500 dark:hover:bg-white/[0.06] dark:hover:text-gray-200">
+                                        <ChevronUp className="h-3.5 w-3.5" />
+                                    </button>
+                                    <button
+                                        type="button"
+                                        aria-label={`Move ${tab.project} down`}
+                                        onClick={() => handleMove(tab.project, 'down')}
+                                        disabled={isSaving || index === localTabs.length - 1}
+                                        className="rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 disabled:pointer-events-none disabled:opacity-30 dark:text-gray-500 dark:hover:bg-white/[0.06] dark:hover:text-gray-200">
+                                        <ChevronDown className="h-3.5 w-3.5" />
+                                    </button>
+                                </div>
                                 <span className="text-sm text-gray-700 dark:text-gray-300 truncate font-mono text-xs">
                                     {tab.project}
                                 </span>

--- a/packages/web/src/features/dashboard/hooks/__tests__/useDashboardActions.test.tsx
+++ b/packages/web/src/features/dashboard/hooks/__tests__/useDashboardActions.test.tsx
@@ -5,6 +5,7 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
 import {useDashboardActions} from '../useDashboardActions'
 import * as authFetch from '@features/authentication/utils/authFetch'
 import * as testsStore from '@features/tests/store/testsStore'
+import {config} from '@config/environment.config'
 
 // Mock dependencies
 vi.mock('@features/authentication/utils/authFetch')
@@ -264,6 +265,73 @@ describe('useDashboardActions', () => {
                 )
                 expect(invalidateQueriesSpy).toHaveBeenCalled()
             })
+        })
+    })
+
+    describe('clearAllData with a project', () => {
+        it('should confirm with a project-specific message and call the scoped endpoint', async () => {
+            confirmSpy.mockReturnValue(true)
+
+            const mockResponse = {
+                ok: true,
+                json: async () => ({data: {deletedExecutions: 30}}),
+            }
+            vi.mocked(authFetch.authFetch).mockResolvedValue(mockResponse as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.clearAllData('API_Tests')
+
+            expect(confirmSpy).toHaveBeenCalledWith(
+                expect.stringContaining('clear ALL test data for project "API_Tests"')
+            )
+            const [url] = vi.mocked(authFetch.authFetch).mock.calls[0]
+            expect(url).toBe(`${config.api.baseUrl}/tests/all?project=API_Tests`)
+        })
+
+        it('should show a project-scoped success alert using deletedExecutions', async () => {
+            confirmSpy.mockReturnValue(true)
+
+            const mockResponse = {
+                ok: true,
+                json: async () => ({data: {deletedExecutions: 30}}),
+            }
+            vi.mocked(authFetch.authFetch).mockResolvedValue(mockResponse as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.clearAllData('API_Tests')
+
+            await waitFor(() => {
+                expect(alertSpy).toHaveBeenCalledWith(
+                    '✅ Success! Cleared 30 executions for project "API_Tests"'
+                )
+            })
+            expect(mockFetchTests).toHaveBeenCalled()
+        })
+
+        it('should URL-encode the project name in the request', async () => {
+            confirmSpy.mockReturnValue(true)
+
+            const mockResponse = {
+                ok: true,
+                json: async () => ({data: {deletedExecutions: 1}}),
+            }
+            vi.mocked(authFetch.authFetch).mockResolvedValue(mockResponse as any)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.clearAllData('Mobile Chrome')
+
+            const [url] = vi.mocked(authFetch.authFetch).mock.calls[0]
+            expect(url).toContain('project=Mobile%20Chrome')
+        })
+
+        it('should not call the API when the user cancels the scoped confirmation', async () => {
+            confirmSpy.mockReturnValue(false)
+
+            const {result} = renderHook(() => useDashboardActions(), {wrapper})
+            await result.current.clearAllData('API_Tests')
+
+            expect(authFetch.authFetch).not.toHaveBeenCalled()
+            expect(mockFetchTests).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/web/src/features/dashboard/hooks/useDashboardActions.ts
+++ b/packages/web/src/features/dashboard/hooks/useDashboardActions.ts
@@ -7,7 +7,7 @@ import {useTestsStore} from '@features/tests/store/testsStore'
 export interface UseDashboardActionsReturn {
     clearingData: boolean
     cleaningData: boolean
-    clearAllData: () => Promise<void>
+    clearAllData: (project?: string) => Promise<void>
     cleanupData: (
         type: 'date' | 'count',
         value: string | number,
@@ -21,18 +21,21 @@ export function useDashboardActions(): UseDashboardActionsReturn {
     const [clearingData, setClearingData] = useState(false)
     const [cleaningData, setCleaningData] = useState(false)
 
-    const clearAllData = async () => {
-        if (
-            !confirm(
-                '⚠️ Are you sure you want to clear ALL test data? This action cannot be undone.'
-            )
-        ) {
+    const clearAllData = async (project?: string) => {
+        const confirmMessage = project
+            ? `⚠️ Are you sure you want to clear ALL test data for project "${project}"? This action cannot be undone.`
+            : '⚠️ Are you sure you want to clear ALL test data? This action cannot be undone.'
+
+        if (!confirm(confirmMessage)) {
             return
         }
 
         setClearingData(true)
         try {
-            const response = await authFetch(`${config.api.baseUrl}/tests/all`, {
+            const url = project
+                ? `${config.api.baseUrl}/tests/all?project=${encodeURIComponent(project)}`
+                : `${config.api.baseUrl}/tests/all`
+            const response = await authFetch(url, {
                 method: 'DELETE',
             })
 
@@ -41,14 +44,22 @@ export function useDashboardActions(): UseDashboardActionsReturn {
             }
 
             const result = await response.json()
-            const statsBefore = result.data?.statsBefore || {}
-            const totalRuns = statsBefore.totalRuns || 0
-            const totalResults = statsBefore.totalTests || 0
-            const totalAttachments = statsBefore.totalAttachments || 0
 
-            alert(
-                `✅ Success! Cleared ${totalRuns} runs, ${totalResults} results, ${totalAttachments} attachments`
-            )
+            if (project) {
+                const deletedExecutions = result.data?.deletedExecutions || 0
+                alert(
+                    `✅ Success! Cleared ${deletedExecutions} executions for project "${project}"`
+                )
+            } else {
+                const statsBefore = result.data?.statsBefore || {}
+                const totalRuns = statsBefore.totalRuns || 0
+                const totalResults = statsBefore.totalTests || 0
+                const totalAttachments = statsBefore.totalAttachments || 0
+
+                alert(
+                    `✅ Success! Cleared ${totalRuns} runs, ${totalResults} results, ${totalAttachments} attachments`
+                )
+            }
 
             fetchTests()
 

--- a/packages/web/src/features/tests/components/TestsListFilters.tsx
+++ b/packages/web/src/features/tests/components/TestsListFilters.tsx
@@ -1,8 +1,9 @@
-import {Play} from 'lucide-react'
-import {RefObject} from 'react'
+import {Play, ChevronDown, Search} from 'lucide-react'
+import {RefObject, useRef, useState} from 'react'
 import {FilterButtonGroup, SearchInput, Button} from '@shared/components'
 import {FilterKey, FILTER_OPTIONS} from '../constants'
 import {useTestsStore} from '../store/testsStore'
+import {useClickOutside} from '@/hooks/useClickOutside'
 
 export interface TestsListFiltersProps {
     filter: FilterKey
@@ -34,8 +35,14 @@ export function TestsListFilters({
     searchInputRef,
     activeProject,
 }: TestsListFiltersProps) {
-    const {runAllTests, isRunningAllTests, getIsAnyTestRunning} = useTestsStore()
+    const {runAllTests, discoverTests, isRunningAllTests, isDiscovering, getIsAnyTestRunning} =
+        useTestsStore()
     const isAnyTestRunning = getIsAnyTestRunning()
+    const [showDiscoverMenu, setShowDiscoverMenu] = useState(false)
+    const splitButtonRef = useRef<HTMLDivElement>(null)
+    useClickOutside(splitButtonRef, showDiscoverMenu, () => setShowDiscoverMenu(false))
+
+    const isDisabled = isAnyTestRunning || !activeProject
 
     const filterOptions = FILTER_OPTIONS.map((option) => ({
         ...option,
@@ -46,21 +53,51 @@ export function TestsListFilters({
         <div className="space-y-2 md:space-y-0 md:flex md:items-center md:gap-3">
             {/* Row 1 on mobile / left part on desktop: Run All + Search */}
             <div className="flex items-center gap-2 shrink-0">
-                <div className="relative inline-flex shrink-0 group/noproject">
-                    <Button
-                        variant="primary"
-                        loading={isRunningAllTests}
-                        disabled={isAnyTestRunning || !activeProject}
-                        onClick={() => runAllTests(activeProject || undefined)}>
-                        {isRunningAllTests ? (
-                            'Running...'
-                        ) : (
-                            <span className="flex items-center gap-1.5">
-                                <Play className="h-3.5 w-3.5" />
-                                <span>Run All</span>
-                            </span>
-                        )}
-                    </Button>
+                <div className="relative inline-flex shrink-0 group/noproject" ref={splitButtonRef}>
+                    <div className="inline-flex rounded-xl shadow-soft">
+                        <Button
+                            variant="primary"
+                            loading={isRunningAllTests}
+                            disabled={isDisabled}
+                            onClick={() => {
+                                setShowDiscoverMenu(false)
+                                runAllTests(activeProject || undefined)
+                            }}
+                            className="rounded-r-none shadow-none">
+                            {isRunningAllTests ? (
+                                'Running...'
+                            ) : (
+                                <span className="flex items-center gap-1.5">
+                                    <Play className="h-3.5 w-3.5" />
+                                    <span>Run All</span>
+                                </span>
+                            )}
+                        </Button>
+                        <Button
+                            variant="primary"
+                            loading={isDiscovering}
+                            disabled={isDisabled}
+                            onClick={() => setShowDiscoverMenu((open) => !open)}
+                            aria-label="Discovery options"
+                            aria-expanded={showDiscoverMenu}
+                            className="rounded-l-none shadow-none border-l border-white/20 px-2 dark:border-black/20">
+                            {!isDiscovering && <ChevronDown className="h-3.5 w-3.5" />}
+                        </Button>
+                    </div>
+                    {showDiscoverMenu && (
+                        <div className="absolute top-full left-0 z-50 mt-2 min-w-[180px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-gray-800">
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setShowDiscoverMenu(false)
+                                    discoverTests(activeProject)
+                                }}
+                                className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/[0.06]">
+                                <Search className="h-3.5 w-3.5" />
+                                Discover Tests
+                            </button>
+                        </div>
+                    )}
                     {!activeProject && (
                         <span className="pointer-events-none absolute top-full left-0 z-50 mt-3 whitespace-nowrap rounded-xl bg-primary-600 px-4 py-2.5 text-sm font-medium text-white opacity-0 shadow-xl shadow-primary-900/30 transition-opacity group-hover/noproject:opacity-100 dark:bg-primary-500">
                             Select a project tab to run tests

--- a/packages/web/src/features/tests/store/testsStore.ts
+++ b/packages/web/src/features/tests/store/testsStore.ts
@@ -28,7 +28,7 @@ interface TestsState {
     rerunTest: (testId: string) => Promise<void>
     deleteTest: (testId: string) => Promise<void>
     deleteExecution: (testId: string, executionId: string) => Promise<void>
-    discoverTests: () => Promise<void>
+    discoverTests: (project?: string) => Promise<void>
     runAllTests: (project?: string) => Promise<void>
     runTestsGroup: (filePath: string, testNames?: string[], project?: string) => Promise<void>
     clearError: () => void
@@ -235,11 +235,13 @@ export const useTestsStore = create<TestsState>()(
                 }
             },
 
-            discoverTests: async () => {
+            discoverTests: async (project?: string) => {
                 try {
                     set({isDiscovering: true, error: null})
 
-                    const response = await authPost(`${API_BASE_URL}/tests/discovery`)
+                    const response = await authPost(`${API_BASE_URL}/tests/discovery`, {
+                        project: project || undefined,
+                    })
 
                     if (!response.ok) {
                         throw new Error(`HTTP error! status: ${response.status}`)
@@ -272,7 +274,8 @@ export const useTestsStore = create<TestsState>()(
                         set({isDiscovering: true, error: null})
                         try {
                             const discoveryResponse = await authPost(
-                                `${API_BASE_URL}/tests/discovery`
+                                `${API_BASE_URL}/tests/discovery`,
+                                {project: project || undefined}
                             )
                             if (!discoveryResponse.ok) {
                                 throw new Error(`HTTP error! status: ${discoveryResponse.status}`)

--- a/packages/web/src/hooks/useClickOutside.ts
+++ b/packages/web/src/hooks/useClickOutside.ts
@@ -1,0 +1,20 @@
+import {RefObject, useEffect} from 'react'
+
+export function useClickOutside(
+    ref: RefObject<HTMLElement>,
+    isActive: boolean,
+    onOutsideClick: () => void
+) {
+    useEffect(() => {
+        if (!isActive) return
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                onOutsideClick()
+            }
+        }
+
+        document.addEventListener('mousedown', handleClickOutside)
+        return () => document.removeEventListener('mousedown', handleClickOutside)
+    }, [isActive, ref, onOutsideClick])
+}


### PR DESCRIPTION
- Enhanced the test discovery process to allow scoping to a specific project, improving the management of test results and pending statuses.
- Added functionality to clear test data for individual projects, ensuring that operations do not affect other projects.
- Updated relevant services and repositories to support project-specific operations, including new methods for fetching and deleting test data by project.
- Improved documentation in CLAUDE.md and testing rules to reflect these changes.