### PR TITLE
refactor: Update grep pattern construction for Playwright tests

### DIFF
--- a/packages/server/src/services/__tests__/playwright.service.test.ts
+++ b/packages/server/src/services/__tests__/playwright.service.test.ts
@@ -777,7 +777,7 @@ describe('PlaywrightService', () => {
             const grepIndex = args.indexOf('--grep')
             const grepPattern = args[grepIndex + 1]
             expect(grepPattern).toBe(
-                '(?<![a-zA-Z])Login Test(?![a-zA-Z])|(?<![a-zA-Z])Logout Test(?![a-zA-Z])'
+                '(?<!\\S)Login Test(?:\\s+@\\S+)*$|(?<!\\S)Logout Test(?:\\s+@\\S+)*$'
             )
         })
 
@@ -847,7 +847,7 @@ describe('PlaywrightService', () => {
             const args = mockSpawn.mock.calls[0][1]
             const grepIndex = args.indexOf('--grep')
             const grepPattern = args[grepIndex + 1]
-            expect(grepPattern).toBe('(?<![a-zA-Z])Single Test(?![a-zA-Z])')
+            expect(grepPattern).toBe('(?<!\\S)Single Test(?:\\s+@\\S+)*$')
         })
     })
 
@@ -871,7 +871,7 @@ describe('PlaywrightService', () => {
                     'test',
                     'auth.spec.ts',
                     '--grep',
-                    '(?<![a-zA-Z])should login successfully(?![a-zA-Z])', // Pattern uses lookahead/lookbehind to match exact test name
+                    '(?<!\\S)should login successfully(?:\\s+@\\S+)*$', // Title anchored at end so prefix-sharing tests are not selected
                     '--reporter=json,playwright-dashboard-reporter',
                 ],
                 expect.anything()
@@ -941,7 +941,7 @@ describe('PlaywrightService', () => {
             expect(grepIndex).toBeGreaterThan(-1)
             // Special characters should be escaped
             expect(args[grepIndex + 1]).toBe(
-                '(?<![a-zA-Z])test with \\(parentheses\\) and \\[brackets\\](?![a-zA-Z])'
+                '(?<!\\S)test with \\(parentheses\\) and \\[brackets\\](?:\\s+@\\S+)*$'
             )
         })
 
@@ -956,9 +956,17 @@ describe('PlaywrightService', () => {
             const args = mockSpawn.mock.calls[0][1]
             const grepIndex = args.indexOf('--grep')
             expect(grepIndex).toBeGreaterThan(-1)
-            // Pattern should use negative lookahead/lookbehind to match exact test name
-            expect(args[grepIndex + 1]).toBe('(?<![a-zA-Z])Successful Login(?![a-zA-Z])')
-            // This prevents matching "Unsuccessful Login with invalid email"
+            // Pattern anchors the title at the end of Playwright's combined title string
+            expect(args[grepIndex + 1]).toBe('(?<!\\S)Successful Login(?:\\s+@\\S+)*$')
+
+            // Guard the actual matching semantics, not just the pattern shape
+            const regex = new RegExp(args[grepIndex + 1])
+            expect(regex.test('chromium login.spec.ts Successful Login')).toBe(true)
+            expect(regex.test('chromium login.spec.ts Successful Login @smoke')).toBe(true)
+            expect(regex.test('chromium login.spec.ts Unsuccessful Login with invalid email')).toBe(
+                false
+            )
+            expect(regex.test('chromium login.spec.ts Successful Login with 2FA')).toBe(false)
         })
 
         it('should return message indicating test rerun', async () => {

--- a/packages/server/src/services/playwright.service.ts
+++ b/packages/server/src/services/playwright.service.ts
@@ -152,12 +152,7 @@ export class PlaywrightService implements IPlaywrightService {
         const runId = uuidv4()
         Logger.testRerun(testName, runId)
 
-        // Escape special regex characters and use negative lookahead/lookbehind for precise matching
-        // This prevents partial matches (e.g., "Successful Login" matching "Unsuccessful Login")
-        // Using (?<![a-zA-Z]) and (?![a-zA-Z]) ensures test name is not part of a longer word
-        // This works with Playwright's full test path format which includes describe blocks
-        const escapedTestName = testName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        const grepPattern = `(?<![a-zA-Z])${escapedTestName}(?![a-zA-Z])`
+        const grepPattern = this.buildGrepPattern([testName])
 
         const args = ['playwright', 'test', testFile, '--grep', grepPattern]
         if (maxWorkers) {
@@ -433,16 +428,18 @@ export class PlaywrightService implements IPlaywrightService {
     }
 
     /**
-     * Builds a grep pattern for filtering specific tests by name
-     * Uses negative lookahead/lookbehind to prevent partial matches
+     * Builds a grep pattern for filtering specific tests by name.
+     *
+     * Playwright matches --grep against "<project> <file> <describe...> <title> <tags>"
+     * joined by single spaces, so the title must be anchored as the trailing segment —
+     * otherwise "Create invoice" also selects "Create invoice with delay release".
+     * Optional `@tag` suffixes (from the `tag` test option) are allowed after the title.
      * Multiple test names are combined with OR operator (|)
      */
     private buildGrepPattern(testNames: string[]): string {
         const patterns = testNames.map((name) => {
-            // Escape special regex characters
             const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            // Use negative lookahead/lookbehind for precise matching
-            return `(?<![a-zA-Z])${escapedName}(?![a-zA-Z])`
+            return `(?<!\\S)${escapedName}(?:\\s+@\\S+)*$`
         })
         // Combine all patterns with OR operator
         return patterns.join('|')


### PR DESCRIPTION
- Replaced the regex construction for test name filtering to use a more precise pattern that anchors the title at the end, preventing partial matches with similar test names.
- Updated related test cases to reflect the new grep pattern format, ensuring accurate matching semantics in Playwright's test execution.
- Enhanced documentation within the code to clarify the changes in grep pattern logic and its implications for test name filtering.